### PR TITLE
fix a corner case where the database column is null

### DIFF
--- a/gto-support-db/src/androidTest/java/org/ccci/gto/android/common/db/AbstractDaoIT.java
+++ b/gto-support-db/src/androidTest/java/org/ccci/gto/android/common/db/AbstractDaoIT.java
@@ -213,9 +213,7 @@ public class AbstractDaoIT extends InstrumentationTestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        final TestDao dao = getDao();
-        dao.delete(Root.class, null);
-        dao.delete(Compound.class, null);
+        getDao().reset();
         super.tearDown();
     }
 }

--- a/gto-support-db/src/androidTest/java/org/ccci/gto/android/common/db/util/CursorUtilsIT.java
+++ b/gto-support-db/src/androidTest/java/org/ccci/gto/android/common/db/util/CursorUtilsIT.java
@@ -1,0 +1,65 @@
+package org.ccci.gto.android.common.db.util;
+
+import android.database.Cursor;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.InstrumentationTestCase;
+
+import org.ccci.gto.android.common.db.Contract.RootTable;
+import org.ccci.gto.android.common.db.Query;
+import org.ccci.gto.android.common.db.TestDao;
+import org.ccci.gto.android.common.db.model.Compound;
+import org.ccci.gto.android.common.db.model.Root;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public class CursorUtilsIT extends InstrumentationTestCase {
+    private TestDao getDao() {
+        return TestDao.getInstance(getInstrumentation().getContext());
+    }
+
+    @Test
+    public void testGetStringDefaultValue() throws Exception {
+        final TestDao dao = getDao();
+        final String defValue = "default";
+
+        // create a couple objects to test
+        dao.insert(new Root(1, null));
+        dao.insert(new Root(2, ""));
+        dao.insert(new Root(3, "3"));
+
+        // test default when field isn't present
+        Cursor c = dao.getCursor(Query.select(Root.class).projection(RootTable.COLUMN_ID).orderBy(RootTable.COLUMN_ID));
+        c.moveToPosition(-1);
+        while (c.moveToNext()) {
+            assertThat(CursorUtils.getString(c, RootTable.COLUMN_TEST, defValue), is(defValue));
+        }
+        c.close();
+
+        // test default when field is present
+        c = dao.getCursor(Query.select(Root.class).orderBy(RootTable.COLUMN_ID));
+        c.moveToPosition(0);
+        assertThat(CursorUtils.getLong(c, RootTable.COLUMN_ID), is(1L));
+        assertThat("null column value should return default value",
+                   CursorUtils.getString(c, RootTable.COLUMN_TEST, defValue), is(defValue));
+        c.moveToPosition(1);
+        assertThat(CursorUtils.getLong(c, RootTable.COLUMN_ID), is(2L));
+        assertThat(CursorUtils.getString(c, RootTable.COLUMN_TEST, defValue), is(not(defValue)));
+        c.moveToPosition(2);
+        assertThat(CursorUtils.getLong(c, RootTable.COLUMN_ID), is(3L));
+        assertThat(CursorUtils.getString(c, RootTable.COLUMN_TEST, defValue), is(not(defValue)));
+        c.close();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        final TestDao dao = getDao();
+        dao.delete(Root.class, null);
+        dao.delete(Compound.class, null);
+        super.tearDown();
+    }
+}

--- a/gto-support-db/src/androidTest/java/org/ccci/gto/android/common/db/util/CursorUtilsIT.java
+++ b/gto-support-db/src/androidTest/java/org/ccci/gto/android/common/db/util/CursorUtilsIT.java
@@ -57,9 +57,7 @@ public class CursorUtilsIT extends InstrumentationTestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        final TestDao dao = getDao();
-        dao.delete(Root.class, null);
-        dao.delete(Compound.class, null);
+        getDao().reset();
         super.tearDown();
     }
 }

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/util/CursorUtils.java
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/util/CursorUtils.java
@@ -65,18 +65,27 @@ public final class CursorUtils {
         return getString(c, field, null);
     }
 
+    /**
+     * @param c        The Cursor we are fetching the value from
+     * @param column   The column we are requesting the value of
+     * @param defValue The default value to return when the column doesn't exist or is null
+     * @return the value for the specified column in the current row of the specified Cursor. Or the default value
+     * if the column is null or non-existant
+     */
     @Nullable
-    public static String getString(@NonNull final Cursor c, @NonNull final String field,
+    public static String getString(@NonNull final Cursor c, @NonNull final String column,
                                    @Nullable final String defValue) {
-        final int index = c.getColumnIndex(field);
-        return index != -1 ? c.getString(index) : defValue;
+        final int index = c.getColumnIndex(column);
+        final String value = index != -1 ? c.getString(index) : null;
+        return value != null ? value : defValue;
     }
 
     @NonNull
     public static String getNonNullString(@NonNull final Cursor c, @NonNull final String field,
                                           @NonNull final String defValue) {
-        final String val = getString(c, field, defValue);
-        return val != null ? val : defValue;
+        // if defValue is @NonNull, then getString() will return @NonNull
+        //noinspection ConstantConditions
+        return getString(c, field, defValue);
     }
 
     @Nullable

--- a/gto-support-db/src/testCommon/java/org/ccci/gto/android/common/db/Contract.java
+++ b/gto-support-db/src/testCommon/java/org/ccci/gto/android/common/db/Contract.java
@@ -7,21 +7,21 @@ import org.ccci.gto.android.common.db.model.Root;
 import static org.ccci.gto.android.common.db.Expression.bind;
 import static org.ccci.gto.android.common.db.Expression.field;
 
-class Contract extends BaseContract {
-    static class RootTable implements Base {
+public class Contract extends BaseContract {
+    public static class RootTable implements Base {
         static final String TABLE_NAME = "root";
         static final Table<Root> TABLE = Table.forClass(Root.class);
 
-        static final String COLUMN_ID = _ID;
-        static final String COLUMN_TEST = "test";
+        public static final String COLUMN_ID = _ID;
+        public static final String COLUMN_TEST = "test";
+
+        public static final Field FIELD_ID = field(TABLE, COLUMN_ID);
+        static final Field FIELD_TEST = field(TABLE, COLUMN_TEST);
 
         static final String[] PROJECTION_ALL = {COLUMN_ID, COLUMN_TEST};
 
         static final String SQL_COLUMN_ID = COLUMN_ID + " INTEGER PRIMARY KEY";
         static final String SQL_COLUMN_TEST = COLUMN_TEST + " TEXT";
-
-        static final Field FIELD_ID = field(TABLE, COLUMN_ID);
-        static final Field FIELD_TEST = field(TABLE, COLUMN_TEST);
 
         static final Expression SQL_WHERE_PRIMARY_KEY = FIELD_ID.eq(bind());
 

--- a/gto-support-db/src/testCommon/java/org/ccci/gto/android/common/db/TestDao.java
+++ b/gto-support-db/src/testCommon/java/org/ccci/gto/android/common/db/TestDao.java
@@ -43,4 +43,9 @@ public class TestDao extends AbstractDao {
         }
         return super.getPrimaryKeyWhere(obj);
     }
+
+    public void reset() {
+        delete(Root.class, null);
+        delete(Compound.class, null);
+    }
 }

--- a/gto-support-db/src/testCommon/java/org/ccci/gto/android/common/db/TestDao.java
+++ b/gto-support-db/src/testCommon/java/org/ccci/gto/android/common/db/TestDao.java
@@ -20,7 +20,7 @@ public class TestDao extends AbstractDao {
     }
 
     private static TestDao INSTANCE;
-    static TestDao getInstance(@NonNull final Context context) {
+    public static TestDao getInstance(@NonNull final Context context) {
         synchronized (TestDao.class) {
             if (INSTANCE == null) {
                 INSTANCE = new TestDao(context.getApplicationContext());


### PR DESCRIPTION
The problem was that the default value was only being used if we didn't have the specified column in the result set, but not based on if the field was actually null.

We document this behavior to make the expected behavior clear.