### PR TITLE
add support for JsonApiType aliases

### DIFF
--- a/gto-support-jsonapi/src/androidTest/java/org/ccci/gto/android/common/jsonapi/JsonApiConverterIT.java
+++ b/gto-support-jsonapi/src/androidTest/java/org/ccci/gto/android/common/jsonapi/JsonApiConverterIT.java
@@ -163,6 +163,27 @@ public class JsonApiConverterIT {
     }
 
     @Test
+    public void verifyFromJsonSimpleAlias() throws Exception {
+        final JsonApiConverter converter = new JsonApiConverter.Builder().addClasses(ModelSimple.class).build();
+
+        // valid types
+        for (final String type : new String[] {ModelSimple.TYPE, ModelSimple.ALIAS1, ModelSimple.ALIAS2}) {
+            final JsonApiObject<ModelSimple> output =
+                    converter.fromJson("{data:{type:'" + type + "',id=79}}", ModelSimple.class);
+            final ModelSimple obj = output.getDataSingle();
+            assertNotNull(obj);
+            assertThat(obj.mId, is(79));
+        }
+
+        // invalid types
+        for (final String type : new String[] {ModelSimple.NOTALIAS}) {
+            final JsonApiObject<ModelSimple> output =
+                    converter.fromJson("{data:{type:'" + type + "',id=79}}", ModelSimple.class);
+            assertNull(output.getDataSingle());
+        }
+    }
+
+    @Test
     public void verifyFromJsonAttributes() throws Exception {
         final JsonApiConverter converter = new JsonApiConverter.Builder().addClasses(ModelAttributes.class).build();
 
@@ -283,9 +304,12 @@ public class JsonApiConverterIT {
         }
     }
 
-    @JsonApiType(ModelSimple.TYPE)
+    @JsonApiType(value = ModelSimple.TYPE, aliases = {ModelSimple.ALIAS1, ModelSimple.ALIAS2})
     public static final class ModelSimple extends ModelBase {
         static final String TYPE = "simple";
+        static final String ALIAS1 = "aliased";
+        static final String ALIAS2 = "simple_alias";
+        static final String NOTALIAS = "notsimple";
 
         public ModelSimple() {}
 

--- a/gto-support-jsonapi/src/main/java/org/ccci/gto/android/common/jsonapi/JsonApiConverter.java
+++ b/gto-support-jsonapi/src/main/java/org/ccci/gto/android/common/jsonapi/JsonApiConverter.java
@@ -84,6 +84,17 @@ public final class JsonApiConverter {
             // store this type
             mTypes.put(type, c);
             mFields.put(c, getFields(c));
+
+            // handle any type aliases
+            for (final String alias : getResourceTypeAliases(c)) {
+                // throw an exception if the specified alias is already defined
+                if (mTypes.containsKey(alias)) {
+                    throw new IllegalArgumentException(
+                            "Duplicate @JsonApiType(\"" + alias + "\") shared by " + mTypes.get(alias) + " and " + c);
+                }
+
+                mTypes.put(alias, c);
+            }
         }
     }
 
@@ -366,6 +377,12 @@ public final class JsonApiConverter {
     private String getResourceType(@NonNull final Class<?> clazz) {
         final JsonApiType type = clazz.getAnnotation(JsonApiType.class);
         return type != null ? type.value() : null;
+    }
+
+    @NonNull
+    private String[] getResourceTypeAliases(@NonNull final Class<?> clazz) {
+        final JsonApiType type = clazz.getAnnotation(JsonApiType.class);
+        return type != null ? type.aliases() : new String[0];
     }
 
     @NonNull

--- a/gto-support-jsonapi/src/main/java/org/ccci/gto/android/common/jsonapi/annotation/JsonApiType.java
+++ b/gto-support-jsonapi/src/main/java/org/ccci/gto/android/common/jsonapi/annotation/JsonApiType.java
@@ -9,4 +9,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface JsonApiType {
     String value();
+
+    String[] aliases() default {};
 }


### PR DESCRIPTION
This will allow APIs that return the same objects under different types to be aliased to the same object