### PR TITLE
Don't trigger update while we are currently in a layout pass

### DIFF
--- a/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/SimplePicassoImageView.java
+++ b/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/SimplePicassoImageView.java
@@ -89,6 +89,22 @@ public class SimplePicassoImageView extends ImageView implements PicassoImageVie
     }
 
     @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (mHelper != null) {
+            mHelper.onAttachedToWindow();
+        }
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        if (mHelper != null) {
+            mHelper.onDetachedFromWindow();
+        }
+    }
+
+    @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
         mHelper.onSizeChanged(w, h, oldw, oldh);


### PR DESCRIPTION
If Picasso has cached the processed image in memory, it will immediately set the image on the ImageView, which will request a layout that can't be honored. This can cause views to not re-measure themselves to adjust for different image sizes