### PR TITLE
truncate leak crashlytics log

### DIFF
--- a/gto-support-leakcanary/src/main/java/org/ccci/gto/android/common/leakcanary/CrashlyticsLeakService.java
+++ b/gto-support-leakcanary/src/main/java/org/ccci/gto/android/common/leakcanary/CrashlyticsLeakService.java
@@ -8,6 +8,8 @@ import com.squareup.leakcanary.DisplayLeakService;
 import com.squareup.leakcanary.HeapDump;
 
 public class CrashlyticsLeakService extends DisplayLeakService {
+    private static final int LOG_LIMIT = 64 * 1024;
+
     @NonNull
     private static String classSimpleName(@NonNull final String className) {
         int separator = className.lastIndexOf('.');
@@ -15,15 +17,20 @@ public class CrashlyticsLeakService extends DisplayLeakService {
     }
 
     protected void afterDefaultHandling(@NonNull final HeapDump heapDump, @NonNull final AnalysisResult result,
-                                        @NonNull final String leakInfo) {
+                                        @NonNull String leakInfo) {
         if (!result.leakFound || result.excludedLeak) {
             return;
         }
+
+        // truncate the leakInfo if it's too long for crashlytics
+        if (leakInfo.length() > LOG_LIMIT) {
+            leakInfo = leakInfo.substring(0, LOG_LIMIT);
+        }
+
         Crashlytics.log("*** Memory Leak ***");
         for (final String s : leakInfo.split("\n")) {
             Crashlytics.log(s);
         }
-        Crashlytics.log("*** End Of Leak ***");
 
         String name = classSimpleName(result.className);
         if (!heapDump.referenceName.equals("")) {


### PR DESCRIPTION
It's more important to get the beginning of a leak than the end of it