### PR TITLE
create a WeakRunnable class

### DIFF
--- a/gto-support-util/src/main/java/org/ccci/gto/android/common/util/WeakTask.java
+++ b/gto-support-util/src/main/java/org/ccci/gto/android/common/util/WeakTask.java
@@ -1,0 +1,29 @@
+package org.ccci.gto.android.common.util;
+
+import android.support.annotation.NonNull;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+
+public final class WeakTask<T> implements Runnable {
+    private final Reference<T> mRef;
+    private final Task<T> mTask;
+
+    public WeakTask(@NonNull final T obj, @NonNull final Task<T> task) {
+        mRef = new WeakReference<>(obj);
+        mTask = task;
+    }
+
+    @Override
+    public void run() {
+        final T obj = mRef.get();
+        if (obj != null) {
+            mTask.run(obj);
+        }
+    }
+
+    @FunctionalInterface
+    public interface Task<T> {
+        void run(@NonNull T obj);
+    }
+}


### PR DESCRIPTION
This will address a common use-case where we want to maintain a weak reference to an object to not leak memory if the object disappears before the runnable executes.