### PR TITLE
handle a different invalid pointer index exception thrown on Huawei devices

### DIFF
--- a/gto-support-util/src/main/java/org/ccci/gto/android/common/util/view/ViewUtils.java
+++ b/gto-support-util/src/main/java/org/ccci/gto/android/common/util/view/ViewUtils.java
@@ -1,12 +1,12 @@
 package org.ccci.gto.android.common.util.view;
 
 import android.app.Activity;
-import androidx.annotation.IdRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.view.View;
 import android.view.ViewParent;
 
+import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 public final class ViewUtils {
@@ -62,6 +62,7 @@ public final class ViewUtils {
     }
 
     private static boolean isMotionEventPointerIndexException(@NonNull final Throwable cause) {
-        return cause instanceof IllegalArgumentException && "pointerIndex out of range".equals(cause.getMessage());
+        return cause instanceof IllegalArgumentException && cause.getMessage() != null &&
+                cause.getMessage().startsWith("pointerIndex out of range");
     }
 }

--- a/gto-support-util/src/test/java/org/ccci/gto/android/common/util/view/ViewUtilsTest.java
+++ b/gto-support-util/src/test/java/org/ccci/gto/android/common/util/view/ViewUtilsTest.java
@@ -1,0 +1,57 @@
+package org.ccci.gto.android.common.util.view;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ViewUtilsTest {
+    private static final Exception[] TOUCH_EXCEPTIONS_TO_SUPPRESS = {
+            new IllegalArgumentException("pointerIndex out of range"),
+            new IllegalArgumentException("pointerIndex out of range pointerIndex=-1 pointerCount=1"),
+    };
+
+    private static final Exception[] TOUCH_EXCEPTIONS_TO_PROPAGATE = {
+            new IllegalArgumentException()
+    };
+
+    @Test
+    public void verifyHandleOnInterceptTouchEventExceptionSuppressed() throws Exception {
+        for (final Exception e : TOUCH_EXCEPTIONS_TO_SUPPRESS) {
+            assertFalse(ViewUtils.handleOnInterceptTouchEventException(e));
+        }
+    }
+
+    @Test
+    public void verifyHandleOnInterceptTouchEventExceptionPropagated() throws Exception {
+        for (final Exception e : TOUCH_EXCEPTIONS_TO_PROPAGATE) {
+            try {
+                ViewUtils.handleOnInterceptTouchEventException(e);
+                fail();
+            } catch (Exception thrown) {
+                assertEquals(e, thrown);
+            }
+        }
+    }
+
+    @Test
+    public void verifyHandleOnTouchEventExceptionSuppressed() throws Exception {
+        for (final Exception e : TOUCH_EXCEPTIONS_TO_SUPPRESS) {
+            assertTrue(ViewUtils.handleOnTouchEventException(e));
+        }
+    }
+
+    @Test
+    public void verifyHandleOnTouchEventExceptionPropagated() throws Exception {
+        for (final Exception e : TOUCH_EXCEPTIONS_TO_PROPAGATE) {
+            try {
+                ViewUtils.handleOnTouchEventException(e);
+                fail();
+            } catch (Exception thrown) {
+                assertEquals(e, thrown);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://console.firebase.google.com/u/0/project/godtools-b2f82/crashlytics/app/android:org.keynote.godtools.android/issues/5bd6d017f8b88c2963a6cbc3?time=last-ninety-days&sessionId=5BE646340071000153CED6F05CB1D896_DNE_0_v2