### PR TITLE
We should trigger executePendingBindings for DataBinding in a RecyclerView

### DIFF
--- a/gto-support-realm/src/main/java/org/ccci/gto/android/common/realm/adapter/RealmDataBindingAdapter.kt
+++ b/gto-support-realm/src/main/java/org/ccci/gto/android/common/realm/adapter/RealmDataBindingAdapter.kt
@@ -21,8 +21,10 @@ abstract class RealmDataBindingAdapter<T : RealmModel, B : ViewDataBinding>(data
 
     protected abstract fun onCreateViewDataBinding(parent: ViewGroup, viewType: Int): B
 
-    override fun onBindViewHolder(holder: DataBindingViewHolder<B>, position: Int) =
+    override fun onBindViewHolder(holder: DataBindingViewHolder<B>, position: Int) {
         onBindViewDataBinding(holder.binding, position)
+        holder.binding.executePendingBindings()
+    }
 
     protected abstract fun onBindViewDataBinding(binding: B, position: Int)
 

--- a/gto-support-recyclerview/src/main/java/org/ccci/gto/android/common/recyclerview/adapter/SimpleDataBindingAdapter.java
+++ b/gto-support-recyclerview/src/main/java/org/ccci/gto/android/common/recyclerview/adapter/SimpleDataBindingAdapter.java
@@ -22,6 +22,7 @@ public abstract class SimpleDataBindingAdapter<B extends ViewDataBinding>
     @Override
     public final void onBindViewHolder(@NonNull final DataBindingViewHolder<B> holder, final int position) {
         onBindViewDataBinding(holder.binding, position);
+        holder.binding.executePendingBindings();
     }
 
     protected abstract void onBindViewDataBinding(@NonNull B binding, int position);


### PR DESCRIPTION
RecyclerViews separate binding data from view layout. Data Binding defers binding to improve performance. These features work against each other, so we should trigger any pending bindings during recyclerview binding logic