### PR TITLE
LayerDrawable.children extension property

### DIFF
--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/drawable/LayerDrawableUtils.kt
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/drawable/LayerDrawableUtils.kt
@@ -4,4 +4,4 @@ package org.ccci.gto.android.common.drawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 
-fun LayerDrawable.children(): Sequence<Drawable?> = (0 until numberOfLayers).asSequence().map { getDrawable(it) }
+val LayerDrawable.children: Sequence<Drawable?> get() = (0 until numberOfLayers).asSequence().map { getDrawable(it) }

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/drawable/LayerDrawableUtils.kt
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/drawable/LayerDrawableUtils.kt
@@ -1,0 +1,7 @@
+@file:JvmName("LayerDrawableUtils")
+package org.ccci.gto.android.common.drawable
+
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.LayerDrawable
+
+fun LayerDrawable.children(): Sequence<Drawable?> = (0 until numberOfLayers).asSequence().map { getDrawable(it) }


### PR DESCRIPTION
provide an extension val to easily iterate over the children of a `LayerDrawable`