### PR TITLE
add an inline reified method to simplify `findLiveData` usage

### DIFF
--- a/gto-support-db-livedata/src/main/java/org/ccci/gto/android/common/db/LiveDataDao.kt
+++ b/gto-support-db-livedata/src/main/java/org/ccci/gto/android/common/db/LiveDataDao.kt
@@ -76,5 +76,6 @@ class LiveDataRegistry {
     }
 }
 
+inline fun <reified T> LiveDataDao.findLiveData(vararg key: Any) = findLiveData(T::class.java, *key)
 fun <T> Query<T>.getAsLiveData(dao: LiveDataDao) = dao.getLiveData(this)
 fun <T> Query<T>.getCursorAsLiveData(dao: LiveDataDao) = dao.getCursorLiveData(this)


### PR DESCRIPTION
this should allow the following kotlin statement to work:
```kotlin
val obj: LiveData<Type?> = dao.findLiveData(id)
```