### PR TITLE
Collection LiveData adjustments

### DIFF
--- a/gto-support-lifecycle/src/main/java/org/ccci/gto/android/common/lifecycle/CollectionLiveData.kt
+++ b/gto-support-lifecycle/src/main/java/org/ccci/gto/android/common/lifecycle/CollectionLiveData.kt
@@ -13,10 +13,7 @@ sealed class CollectionLiveData<T, C : Collection<T>>(
     fun addAll(items: Collection<T>) = collection.addAll(items)
     fun remove(item: T) = collection.remove(item)
     fun removeAll(items: Collection<T>) = collection.removeAll(items)
-
-    fun clear() {
-        collection.clear()
-    }
+    fun clear() = collection.clear()
 
     private fun notifyChanged() = postValue(collection as C)
 

--- a/gto-support-lifecycle/src/main/java/org/ccci/gto/android/common/lifecycle/CollectionLiveData.kt
+++ b/gto-support-lifecycle/src/main/java/org/ccci/gto/android/common/lifecycle/CollectionLiveData.kt
@@ -2,17 +2,20 @@ package org.ccci.gto.android.common.lifecycle
 
 import androidx.lifecycle.LiveData
 
-sealed class CollectionLiveData<T, C : Collection<T>, MC : MutableCollection<T>>(
-    private val collection: MC
+sealed class CollectionLiveData<T, C : Collection<T>>(
+    private val collection: ChangeAwareCollection<T>
 ) : LiveData<C>(collection as C) {
-    fun add(item: T) = collection.add(item).also { if (it) notifyChanged() }
-    fun addAll(items: Collection<T>) = collection.addAll(items).also { if (it) notifyChanged() }
-    fun remove(item: T) = collection.remove(item).also { if (it) notifyChanged() }
-    fun removeAll(items: Collection<T>) = collection.removeAll(items).also { if (it) notifyChanged() }
+    init {
+        collection.liveData = this
+    }
+
+    fun add(item: T) = collection.add(item)
+    fun addAll(items: Collection<T>) = collection.addAll(items)
+    fun remove(item: T) = collection.remove(item)
+    fun removeAll(items: Collection<T>) = collection.removeAll(items)
 
     fun clear() {
         collection.clear()
-        notifyChanged()
     }
 
     private fun notifyChanged() = postValue(collection as C)
@@ -36,7 +39,47 @@ sealed class CollectionLiveData<T, C : Collection<T>, MC : MutableCollection<T>>
     operator fun minusAssign(items: Collection<T>) {
         removeAll(items)
     }
+
+    protected abstract class ChangeAwareCollection<T>(
+        private val delegate: MutableCollection<T>
+    ) : MutableCollection<T> {
+        internal lateinit var liveData: CollectionLiveData<*, *>
+        protected fun notifyChanged() {
+            liveData.notifyChanged()
+        }
+
+        override fun add(element: T) = delegate.add(element).also { if (it) notifyChanged() }
+        override fun addAll(elements: Collection<T>) = delegate.addAll(elements).also { if (it) notifyChanged() }
+        override fun remove(element: T) = delegate.remove(element).also { if (it) notifyChanged() }
+        override fun removeAll(elements: Collection<T>) = delegate.removeAll(elements).also { if (it) notifyChanged() }
+        override fun retainAll(elements: Collection<T>) = delegate.retainAll(elements).also { if (it) notifyChanged() }
+        override fun clear() = delegate.clear().also { notifyChanged() }
+    }
 }
 
-class ListLiveData<T> : CollectionLiveData<T, List<T>, MutableList<T>>(mutableListOf())
-class SetLiveData<T> : CollectionLiveData<T, Set<T>, MutableSet<T>>(mutableSetOf())
+class ListLiveData<T> : CollectionLiveData<T, List<T>>(ChangeAwareList()) {
+    private class ChangeAwareList<T>(
+        private val delegate: MutableList<T> = mutableListOf()
+    ) : ChangeAwareCollection<T>(delegate), MutableList<T>, List<T> by delegate {
+        override fun add(index: Int, element: T) = delegate.add(index, element).also { notifyChanged() }
+        override fun addAll(index: Int, elements: Collection<T>) =
+            delegate.addAll(index, elements).also { if (it) notifyChanged() }
+        override fun removeAt(index: Int) = delegate.removeAt(index).also { notifyChanged() }
+        override fun set(index: Int, element: T) = delegate.set(index, element).also { notifyChanged() }
+
+        // TODO: we should handle any changes made via the iterators
+        override fun iterator() = delegate.iterator()
+        override fun listIterator() = delegate.listIterator()
+        override fun listIterator(index: Int) = delegate.listIterator(index)
+        override fun subList(fromIndex: Int, toIndex: Int) = delegate.subList(fromIndex, toIndex)
+    }
+}
+
+class SetLiveData<T> : CollectionLiveData<T, Set<T>>(ChangeAwareSet()) {
+    private class ChangeAwareSet<T>(
+        private val delegate: MutableSet<T> = mutableSetOf()
+    ) : ChangeAwareCollection<T>(delegate), MutableSet<T>, Set<T> by delegate {
+        // TODO: we should handle any changes made via the iterators
+        override fun iterator() = delegate.iterator()
+    }
+}

--- a/gto-support-lifecycle/src/test/java/org/ccci/gto/android/common/lifecycle/databinding/CollectionLiveDataTests.kt
+++ b/gto-support-lifecycle/src/test/java/org/ccci/gto/android/common/lifecycle/databinding/CollectionLiveDataTests.kt
@@ -23,7 +23,7 @@ abstract class CollectionLiveDataTests {
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
-    abstract val liveData: CollectionLiveData<String, out Collection<String>, *>
+    abstract val liveData: CollectionLiveData<String, out Collection<String>>
     lateinit var observer: Observer<Any?>
 
     @Before

--- a/gto-support-lifecycle/src/test/java/org/ccci/gto/android/common/lifecycle/databinding/CollectionLiveDataTests.kt
+++ b/gto-support-lifecycle/src/test/java/org/ccci/gto/android/common/lifecycle/databinding/CollectionLiveDataTests.kt
@@ -37,42 +37,42 @@ abstract class CollectionLiveDataTests {
     fun testAdd() {
         assertTrue(liveData.add("a"))
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a"))
+        assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testAddAll() {
         assertTrue(liveData.addAll(setOf("a", "b", "c")))
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a", "b", "c"))
+        assertThat(liveData.value, containsInAnyOrder("a", "b", "c"))
     }
 
     @Test
     fun testAddAllEmpty() {
         assertFalse(liveData.addAll(emptySet()))
         verify(observer, never()).onChanged(any())
-        assertThat(liveData.getValue(), empty())
+        assertThat(liveData.value, empty())
     }
 
     @Test
     fun testPlusAssign() {
         liveData += "a"
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a"))
+        assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testPlusAssignCollection() {
         liveData += setOf("a", "b", "c")
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a", "b", "c"))
+        assertThat(liveData.value, containsInAnyOrder("a", "b", "c"))
     }
 
     @Test
     fun testPlusAssignCollectionEmpty() {
         liveData += emptySet()
         verify(observer, never()).onChanged(any())
-        assertThat(liveData.getValue(), empty())
+        assertThat(liveData.value, empty())
     }
 
     @Test
@@ -82,7 +82,7 @@ abstract class CollectionLiveDataTests {
 
         assertTrue(liveData.remove("a"))
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("b"))
+        assertThat(liveData.value, containsInAnyOrder("b"))
     }
 
     @Test
@@ -92,7 +92,7 @@ abstract class CollectionLiveDataTests {
 
         assertFalse(liveData.remove("b"))
         verify(observer, never()).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a"))
+        assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
@@ -102,7 +102,7 @@ abstract class CollectionLiveDataTests {
 
         assertTrue(liveData.removeAll(setOf("b", "c")))
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a"))
+        assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
@@ -112,7 +112,7 @@ abstract class CollectionLiveDataTests {
 
         assertFalse(liveData.removeAll(setOf("b", "c")))
         verify(observer, never()).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a"))
+        assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
@@ -122,7 +122,7 @@ abstract class CollectionLiveDataTests {
 
         liveData -= "a"
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("b"))
+        assertThat(liveData.value, containsInAnyOrder("b"))
     }
 
     @Test
@@ -132,7 +132,7 @@ abstract class CollectionLiveDataTests {
 
         liveData -= "b"
         verify(observer, never()).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a"))
+        assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
@@ -142,7 +142,7 @@ abstract class CollectionLiveDataTests {
 
         liveData -= setOf("b", "c")
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a"))
+        assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
@@ -152,7 +152,7 @@ abstract class CollectionLiveDataTests {
 
         liveData -= setOf("b", "c")
         verify(observer, never()).onChanged(any())
-        assertThat(liveData.getValue(), containsInAnyOrder("a"))
+        assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
@@ -162,14 +162,14 @@ abstract class CollectionLiveDataTests {
 
         liveData.clear()
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), empty())
+        assertThat(liveData.value, empty())
     }
 
     @Test
     fun testClearEmpty() {
         liveData.clear()
         verify(observer).onChanged(any())
-        assertThat(liveData.getValue(), empty())
+        assertThat(liveData.value, empty())
     }
 }
 


### PR DESCRIPTION
Instead of forcing modifications to be made via the LiveData object, enable making changes via the collection stored in LiveData