### PR TITLE
LiveData.observeOnce() extension method

### DIFF
--- a/gto-support-lifecycle/build.gradle
+++ b/gto-support-lifecycle/build.gradle
@@ -6,5 +6,6 @@ dependencies {
     compileOnly "androidx.databinding:databinding-runtime:${deps.androidX.databinding}"
 
     testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
+    testImplementation "androidx.lifecycle:lifecycle-runtime:${deps.androidX.lifecycle}"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${deps.mockitoKotlin}"
 }

--- a/gto-support-lifecycle/src/main/java/org/ccci/gto/android/common/lifecycle/LiveData.kt
+++ b/gto-support-lifecycle/src/main/java/org/ccci/gto/android/common/lifecycle/LiveData.kt
@@ -6,12 +6,17 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 
 @MainThread
-inline fun <T> LiveData<T>.observeOnce(
-    owner: LifecycleOwner,
-    crossinline onChanged: (T) -> Unit
-) = object : Observer<T> {
+inline fun <T> LiveData<T>.observeOnce(owner: LifecycleOwner, crossinline onChanged: (T) -> Unit) =
+    observeOnceObserver(onChanged).also { observe(owner, it) }
+
+@MainThread
+inline fun <T> LiveData<T>.observeOnce(crossinline onChanged: (T) -> Unit) =
+    observeOnceObserver(onChanged).also { observeForever(it) }
+
+@JvmSynthetic
+inline fun <T> LiveData<T>.observeOnceObserver(crossinline onChanged: (T) -> Unit) = object : Observer<T> {
     override fun onChanged(t: T) {
         onChanged.invoke(t)
         removeObserver(this)
     }
-}.also { observe(owner, it) }
+}

--- a/gto-support-lifecycle/src/main/java/org/ccci/gto/android/common/lifecycle/LiveData.kt
+++ b/gto-support-lifecycle/src/main/java/org/ccci/gto/android/common/lifecycle/LiveData.kt
@@ -1,0 +1,17 @@
+package org.ccci.gto.android.common.lifecycle
+
+import androidx.annotation.MainThread
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+
+@MainThread
+inline fun <T> LiveData<T>.observeOnce(
+    owner: LifecycleOwner,
+    crossinline onChanged: (T) -> Unit
+) = object : Observer<T> {
+    override fun onChanged(t: T) {
+        onChanged.invoke(t)
+        removeObserver(this)
+    }
+}.also { observe(owner, it) }

--- a/gto-support-lifecycle/src/test/java/org/ccci/gto/android/common/lifecycle/databinding/LiveDataObserveOnceTest.kt
+++ b/gto-support-lifecycle/src/test/java/org/ccci/gto/android/common/lifecycle/databinding/LiveDataObserveOnceTest.kt
@@ -1,0 +1,62 @@
+package org.ccci.gto.android.common.lifecycle.databinding
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.reset
+import com.nhaarman.mockitokotlin2.verify
+import org.ccci.gto.android.common.lifecycle.observeOnce
+import org.junit.Rule
+import org.junit.Test
+
+class LiveDataObserveOnceTest {
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    private val lifecycleOwner = object : LifecycleOwner {
+        val lifecycleRegistry = LifecycleRegistry(this)
+        override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    }
+    private val liveData = MutableLiveData<Int>()
+
+    @Test
+    fun verifyObserveOnceOnlyCalledOneTime() {
+        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+        // observe before LiveData has data
+        val observer: (Int) -> Unit = mock()
+        liveData.observeOnce(lifecycleOwner, observer)
+        verify(observer, never()).invoke(any())
+        liveData.value = 1
+        verify(observer).invoke(eq(1))
+        reset(observer)
+        liveData.value = 2
+        verify(observer, never()).invoke(any())
+
+        // observe after LiveData has data
+        val observer2: (Int) -> Unit = mock()
+        liveData.observeOnce(lifecycleOwner, observer2)
+        verify(observer2).invoke(eq(2))
+        reset(observer2)
+        liveData.value = 3
+        verify(observer2, never()).invoke(any())
+    }
+
+    @Test
+    fun verifyObserveOnceRespectsLifecycle() {
+        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        val observer: (Int) -> Unit = mock()
+        liveData.observeOnce(lifecycleOwner, observer)
+
+        // Lifecycle is destroyed so observer is removed before it can be called
+        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        liveData.value = 1
+        verify(observer, never()).invoke(any())
+    }
+}

--- a/gto-support-lifecycle/src/test/java/org/ccci/gto/android/common/lifecycle/databinding/LiveDataObserveOnceTest.kt
+++ b/gto-support-lifecycle/src/test/java/org/ccci/gto/android/common/lifecycle/databinding/LiveDataObserveOnceTest.kt
@@ -49,6 +49,27 @@ class LiveDataObserveOnceTest {
     }
 
     @Test
+    fun verifyObserveOnceWithoutLifecycle() {
+        // observe before LiveData has data
+        val observer: (Int) -> Unit = mock()
+        liveData.observeOnce(observer)
+        verify(observer, never()).invoke(any())
+        liveData.value = 1
+        verify(observer).invoke(eq(1))
+        reset(observer)
+        liveData.value = 2
+        verify(observer, never()).invoke(any())
+
+        // observe after LiveData has data
+        val observer2: (Int) -> Unit = mock()
+        liveData.observeOnce(observer2)
+        verify(observer2).invoke(eq(2))
+        reset(observer2)
+        liveData.value = 3
+        verify(observer2, never()).invoke(any())
+    }
+
+    @Test
     fun verifyObserveOnceRespectsLifecycle() {
         lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
         val observer: (Int) -> Unit = mock()


### PR DESCRIPTION
this will allow us to observe LiveData for data, but only receive a single callback with the first available value.

This will be used in the GodTools Manifest parsing refactor