### PR TITLE
GT-745 prevent ConcurrentModificationException in DB LiveData logic

### DIFF
--- a/gto-support-db-livedata/build.gradle
+++ b/gto-support-db-livedata/build.gradle
@@ -3,4 +3,8 @@ dependencies {
 
     implementation "androidx.collection:collection:${deps.androidX.collection}"
     api "androidx.lifecycle:lifecycle-livedata:${deps.androidX.lifecycle}"
+
+    testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${deps.mockitoKotlin}"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
 }

--- a/gto-support-db-livedata/src/test/java/org/ccci/gto/android/common/db/LiveDataRegistryTest.kt
+++ b/gto-support-db-livedata/src/test/java/org/ccci/gto/android/common/db/LiveDataRegistryTest.kt
@@ -1,0 +1,47 @@
+package org.ccci.gto.android.common.db
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
+
+class LiveDataRegistryTest {
+    @get:Rule
+    val instantTaskRule = InstantTaskExecutorRule()
+
+    private val registry = LiveDataRegistry()
+    lateinit var dao: LiveDataDao
+
+    @Before
+    fun setup() {
+        dao = mock()
+        whenever(dao.liveDataRegistry).thenReturn(registry)
+        whenever(dao.findLiveData(Obj::class.java)).thenCallRealMethod()
+    }
+
+    @Test
+    fun verifyinvalidateNoConcurrentModification() {
+        // create 2 racing threads, 1 invalidating LiveData handles, and 1 registering new LiveData handles
+        runBlocking {
+            val shutdown = AtomicBoolean(false)
+            launch(Dispatchers.Default) {
+                while (!shutdown.get()) {
+                    registry.invalidate(Obj::class.java)
+                    yield()
+                }
+            }
+
+            (0..1000).map { dao.findLiveData(Obj::class.java) }
+            shutdown.set(true)
+        }
+    }
+}
+
+class Obj


### PR DESCRIPTION
if the internal registry was updated while we were processing an invalidation it would trigger a `ConcurrentModificationException`