### PR TITLE
Only emit a value in Transformations once the source LiveDatas have been initialized

### DIFF
--- a/gto-support-androidx-lifecycle/src/main/java/androidx/lifecycle/LiveDataInternals.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/androidx/lifecycle/LiveDataInternals.kt
@@ -1,0 +1,5 @@
+package androidx.lifecycle
+
+import androidx.lifecycle.LiveData.START_VERSION
+
+internal val LiveData<*>.isInitialized get() = version > START_VERSION

--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
@@ -56,7 +56,7 @@ private inline fun <OUT> switchCombineWithInt(
 ): LiveData<OUT> {
     val result = MediatorLiveData<OUT>()
     val observer = object : Observer<Any?> {
-        private var isInitialized: Boolean = false
+        private var isInitialized = false
             get() = field || input.all { it.isInitialized }.also { field = it }
         private var source: LiveData<out OUT>? = null
 
@@ -104,7 +104,7 @@ private inline fun <OUT> combineWithInt(
 ): LiveData<OUT> {
     val result = MediatorLiveData<OUT>()
     val observer = object : Observer<Any?> {
-        private var isInitialized: Boolean = false
+        private var isInitialized = false
             get() = field || input.all { it.isInitialized }.also { field = it }
 
         override fun onChanged(t: Any?) {

--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
@@ -5,6 +5,7 @@ package org.ccci.gto.android.common.androidx.lifecycle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.Observer
+import androidx.lifecycle.isInitialized
 import androidx.lifecycle.map
 
 /**
@@ -55,8 +56,12 @@ private inline fun <OUT> switchCombineWithInt(
 ): LiveData<OUT> {
     val result = MediatorLiveData<OUT>()
     val observer = object : Observer<Any?> {
+        private var isInitialized: Boolean = false
+            get() = field || input.all { it.isInitialized }.also { field = it }
         private var source: LiveData<out OUT>? = null
+
         override fun onChanged(t: Any?) {
+            if (!isInitialized) return
             val newSource = mapFunction()
             if (source == newSource) return
             source?.let { result.removeSource(it) }

--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
@@ -18,8 +18,11 @@ import androidx.lifecycle.map
 @JvmName("switchCombine")
 fun <IN1, IN2, OUT> LiveData<IN1>.switchCombineWith(
     other: LiveData<IN2>,
-    mapFunction: (IN1?, IN2?) -> LiveData<out OUT>
-) = switchCombineWithInt(this, other) { mapFunction(value, other.value) }
+    mapFunction: (IN1, IN2) -> LiveData<out OUT>
+) = switchCombineWithInt(this, other) {
+    @Suppress("UNCHECKED_CAST")
+    mapFunction(value as IN1, other.value as IN2)
+}
 
 /**
  * This method will combine 3 LiveData objects into a new LiveData object by running the {@param mapFunction} on the
@@ -32,8 +35,11 @@ fun <IN1, IN2, OUT> LiveData<IN1>.switchCombineWith(
 fun <IN1, IN2, IN3, OUT> LiveData<IN1>.switchCombineWith(
     other: LiveData<IN2>,
     other2: LiveData<IN3>,
-    mapFunction: (IN1?, IN2?, IN3?) -> LiveData<out OUT>
-) = switchCombineWithInt(this, other, other2) { mapFunction(value, other.value, other2.value) }
+    mapFunction: (IN1, IN2, IN3) -> LiveData<out OUT>
+) = switchCombineWithInt(this, other, other2) {
+    @Suppress("UNCHECKED_CAST")
+    mapFunction(value as IN1, other.value as IN2, other2.value as IN3)
+}
 
 /**
  * This method will combine 4 LiveData objects into a new LiveData object by running the {@param mapFunction} on the
@@ -47,8 +53,11 @@ fun <IN1, IN2, IN3, IN4, OUT> LiveData<IN1>.switchCombineWith(
     other: LiveData<IN2>,
     other2: LiveData<IN3>,
     other3: LiveData<IN4>,
-    mapFunction: (IN1?, IN2?, IN3?, IN4?) -> LiveData<out OUT>
-) = switchCombineWithInt(this, other, other2, other3) { mapFunction(value, other.value, other2.value, other3.value) }
+    mapFunction: (IN1, IN2, IN3, IN4) -> LiveData<out OUT>
+) = switchCombineWithInt(this, other, other2, other3) {
+    @Suppress("UNCHECKED_CAST")
+    mapFunction(value as IN1, other.value as IN2, other2.value as IN3, other3.value as IN4)
+}
 
 private inline fun <OUT> switchCombineWithInt(
     vararg input: LiveData<*>,
@@ -82,8 +91,11 @@ private inline fun <OUT> switchCombineWithInt(
 @JvmName("combine")
 fun <IN1, IN2, OUT> LiveData<IN1>.combineWith(
     other: LiveData<IN2>,
-    mapFunction: (IN1?, IN2?) -> OUT
-) = combineWithInt(this, other) { mapFunction(value, other.value) }
+    mapFunction: (IN1, IN2) -> OUT
+) = combineWithInt(this, other) {
+    @Suppress("UNCHECKED_CAST")
+    mapFunction(value as IN1, other.value as IN2)
+}
 
 /**
  * This method will combine 3 LiveData objects into a new LiveData object by running the {@param mapFunction} on the
@@ -95,8 +107,11 @@ fun <IN1, IN2, OUT> LiveData<IN1>.combineWith(
 fun <IN1, IN2, IN3, OUT> LiveData<IN1>.combineWith(
     other: LiveData<IN2>,
     other2: LiveData<IN3>,
-    mapFunction: (IN1?, IN2?, IN3?) -> OUT
-) = combineWithInt(this, other, other2) { mapFunction(value, other.value, other2.value) }
+    mapFunction: (IN1, IN2, IN3) -> OUT
+) = combineWithInt(this, other, other2) {
+    @Suppress("UNCHECKED_CAST")
+    mapFunction(value as IN1, other.value as IN2, other2.value as IN3)
+}
 
 private inline fun <OUT> combineWithInt(
     vararg input: LiveData<*>,

--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
@@ -103,7 +103,15 @@ private inline fun <OUT> combineWithInt(
     crossinline mapFunction: () -> OUT
 ): LiveData<OUT> {
     val result = MediatorLiveData<OUT>()
-    val observer = Observer<Any?> { result.value = mapFunction() }
+    val observer = object : Observer<Any?> {
+        private var isInitialized: Boolean = false
+            get() = field || input.all { it.isInitialized }.also { field = it }
+
+        override fun onChanged(t: Any?) {
+            if (!isInitialized) return
+            result.value = mapFunction()
+        }
+    }
     input.forEach { result.addSource(it, observer) }
     return result
 }

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsTests.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsTests.kt
@@ -20,7 +20,7 @@ class TransformationsTests {
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
-    private val str1 = MutableLiveData("a")
+    private val str1 = MutableLiveData<String>()
     private val str2 = MutableLiveData<String?>()
     private val str3 = MutableLiveData<String?>()
 

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsTests.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsTests.kt
@@ -2,43 +2,55 @@ package org.ccci.gto.android.common.androidx.lifecycle
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 class TransformationsTests {
+    private lateinit var observer: Observer<Any>
+
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
     private val str1 = MutableLiveData("a")
-    private val str2 = MutableLiveData<String?>(null)
-    private val str3 = MutableLiveData<String?>(null)
+    private val str2 = MutableLiveData<String?>()
+    private val str3 = MutableLiveData<String?>()
+
+    @Before
+    fun setup() {
+        observer = mock()
+    }
 
     @Test
     fun verifySwitchCombineWith() {
         val combined = str1.switchCombineWith(str2) { a, b ->
-            when {
-                a == null || b == null -> emptyLiveData<String>()
-                else -> MutableLiveData(a + b)
-            }
+            MutableLiveData(listOfNotNull(a, b).joinToString())
         }
         // observeForever activates the internal MediatorLiveData
-        combined.observeForever { }
+        combined.observeForever(observer)
 
+        verify(observer, never()).onChanged(any())
         assertNull(combined.value)
         str1.value = "b"
+        verify(observer, never()).onChanged(any())
         assertNull(combined.value)
-        str1.value = "a"
-        str2.value = "b"
-        assertEquals("ab", combined.value)
+        str2.value = "c"
+        verify(observer).onChanged(any())
+        assertEquals("b, c", combined.value)
     }
 
     @Test
     fun verifyCombineWith2() {
         val combined = str1.combineWith(str2) { a, b -> listOfNotNull(a, b).joinToString() }
         // observeForever activates the internal MediatorLiveData
-        combined.observeForever { }
+        combined.observeForever(observer)
 
         assertEquals("a", combined.value)
         str1.value = "b"
@@ -51,7 +63,7 @@ class TransformationsTests {
     fun verifyCombineWith3() {
         val combined = str1.combineWith(str2, str3) { a, b, c -> listOfNotNull(a, b, c).joinToString() }
         // observeForever activates the internal MediatorLiveData
-        combined.observeForever { }
+        combined.observeForever(observer)
 
         assertEquals("a", combined.value)
         str1.value = "b"


### PR DESCRIPTION
this is a behavior change for `LiveData.combineWith` and `LiveData.switchCombineWith`. It affects when the initial combined value is available from the result `LiveData`, and when any Observer callback is first triggered.

This change actually makes the result `LiveData` line up with how `LiveData` is supposed to behave around initial values