### PR TITLE
LiveData utilities

### DIFF
--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/EmptyLiveData.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/EmptyLiveData.kt
@@ -2,7 +2,7 @@ package org.ccci.gto.android.common.androidx.lifecycle
 
 import androidx.lifecycle.LiveData
 
-private object EmptyLiveData : LiveData<Nothing?>(null)
+private val EmptyLiveData = ImmutableLiveData(null)
 
 @Suppress("UNCHECKED_CAST")
 fun <T> emptyLiveData(): LiveData<T?> = EmptyLiveData as LiveData<T?>

--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/ImmutableLiveData.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/ImmutableLiveData.kt
@@ -1,0 +1,5 @@
+package org.ccci.gto.android.common.androidx.lifecycle
+
+import androidx.lifecycle.LiveData
+
+class ImmutableLiveData<T>(value: T) : LiveData<T>(value)

--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
@@ -4,6 +4,7 @@ package org.ccci.gto.android.common.androidx.lifecycle
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.isInitialized
 import androidx.lifecycle.map
@@ -132,3 +133,16 @@ private inline fun <OUT> combineWithInt(
 }
 
 fun <T> LiveData<out Iterable<T>>.sortedWith(comparator: Comparator<in T>) = map { it.sortedWith(comparator) }
+
+/**
+ * Transform a LiveData to return an initial value before it has had a chance to resolve it's actual value.
+ * This shouldn't be used with [MutableLiveData] which already has a mechanism to define an initial value.
+ */
+fun <T> LiveData<T>.withInitialValue(value: T) = when {
+    // short-circuit if the LiveData has already loaded an initial value
+    isInitialized -> this
+    else -> MediatorLiveData<T>().also {
+        it.value = value
+        it.addSource(this) { value -> it.value = value }
+    }
+}

--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
@@ -12,6 +12,57 @@ import androidx.lifecycle.map
 /**
  * This method will combine 2 LiveData objects into a new LiveData object by running the {@param mapFunction} on the
  * current values of both source LiveData objects.
+ *
+ * @see androidx.lifecycle.Transformations.map
+ */
+@JvmName("combine")
+fun <IN1, IN2, OUT> LiveData<IN1>.combineWith(
+    other: LiveData<IN2>,
+    mapFunction: (IN1, IN2) -> OUT
+) = combineWithInt(this, other) {
+    @Suppress("UNCHECKED_CAST")
+    mapFunction(value as IN1, other.value as IN2)
+}
+
+/**
+ * This method will combine 3 LiveData objects into a new LiveData object by running the {@param mapFunction} on the
+ * current values of both source LiveData objects.
+ *
+ * @see androidx.lifecycle.Transformations.map
+ */
+@JvmName("combine")
+fun <IN1, IN2, IN3, OUT> LiveData<IN1>.combineWith(
+    other: LiveData<IN2>,
+    other2: LiveData<IN3>,
+    mapFunction: (IN1, IN2, IN3) -> OUT
+) = combineWithInt(this, other, other2) {
+    @Suppress("UNCHECKED_CAST")
+    mapFunction(value as IN1, other.value as IN2, other2.value as IN3)
+}
+
+private inline fun <OUT> combineWithInt(
+    vararg input: LiveData<*>,
+    crossinline mapFunction: () -> OUT
+): LiveData<OUT> {
+    val result = MediatorLiveData<OUT>()
+    val observer = object : Observer<Any?> {
+        private var isInitialized = false
+            get() = field || input.all { it.isInitialized }.also { field = it }
+
+        override fun onChanged(t: Any?) {
+            if (!isInitialized) return
+            result.value = mapFunction()
+        }
+    }
+    input.forEach { result.addSource(it, observer) }
+    return result
+}
+
+fun <T> LiveData<out Iterable<T>>.sortedWith(comparator: Comparator<in T>) = map { it.sortedWith(comparator) }
+
+/**
+ * This method will combine 2 LiveData objects into a new LiveData object by running the {@param mapFunction} on the
+ * current values of both source LiveData objects.
  * Returning either of the original LiveData objects will cause an Exception.
  *
  * @see androidx.lifecycle.Transformations.switchMap
@@ -82,57 +133,6 @@ private inline fun <OUT> switchCombineWithInt(
     input.forEach { result.addSource(it, observer) }
     return result
 }
-
-/**
- * This method will combine 2 LiveData objects into a new LiveData object by running the {@param mapFunction} on the
- * current values of both source LiveData objects.
- *
- * @see androidx.lifecycle.Transformations.map
- */
-@JvmName("combine")
-fun <IN1, IN2, OUT> LiveData<IN1>.combineWith(
-    other: LiveData<IN2>,
-    mapFunction: (IN1, IN2) -> OUT
-) = combineWithInt(this, other) {
-    @Suppress("UNCHECKED_CAST")
-    mapFunction(value as IN1, other.value as IN2)
-}
-
-/**
- * This method will combine 3 LiveData objects into a new LiveData object by running the {@param mapFunction} on the
- * current values of both source LiveData objects.
- *
- * @see androidx.lifecycle.Transformations.map
- */
-@JvmName("combine")
-fun <IN1, IN2, IN3, OUT> LiveData<IN1>.combineWith(
-    other: LiveData<IN2>,
-    other2: LiveData<IN3>,
-    mapFunction: (IN1, IN2, IN3) -> OUT
-) = combineWithInt(this, other, other2) {
-    @Suppress("UNCHECKED_CAST")
-    mapFunction(value as IN1, other.value as IN2, other2.value as IN3)
-}
-
-private inline fun <OUT> combineWithInt(
-    vararg input: LiveData<*>,
-    crossinline mapFunction: () -> OUT
-): LiveData<OUT> {
-    val result = MediatorLiveData<OUT>()
-    val observer = object : Observer<Any?> {
-        private var isInitialized = false
-            get() = field || input.all { it.isInitialized }.also { field = it }
-
-        override fun onChanged(t: Any?) {
-            if (!isInitialized) return
-            result.value = mapFunction()
-        }
-    }
-    input.forEach { result.addSource(it, observer) }
-    return result
-}
-
-fun <T> LiveData<out Iterable<T>>.sortedWith(comparator: Comparator<in T>) = map { it.sortedWith(comparator) }
 
 /**
  * Transform a LiveData to return an initial value before it has had a chance to resolve it's actual value.

--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Transformations.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.isInitialized
 import androidx.lifecycle.map
+import androidx.lifecycle.switchMap
 
 /**
  * This method will combine 2 LiveData objects into a new LiveData object by running the {@param mapFunction} on the
@@ -137,6 +138,14 @@ private inline fun <OUT> switchCombineWithInt(
     }
     return result
 }
+
+inline fun <T, R> LiveData<out Iterable<T>>.switchFold(crossinline operation: (acc: LiveData<R?>, T) -> LiveData<R?>) =
+    switchFold(emptyLiveData(), operation)
+
+inline fun <T, R> LiveData<out Iterable<T>>.switchFold(
+    acc: LiveData<R>,
+    crossinline operation: (acc: LiveData<R>, T) -> LiveData<R>
+) = switchMap { it.fold(acc, operation) }
 
 /**
  * Transform a LiveData to return an initial value before it has had a chance to resolve it's actual value.

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/BaseLiveDataTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/BaseLiveDataTest.kt
@@ -1,0 +1,19 @@
+package org.ccci.gto.android.common.androidx.lifecycle
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.Before
+import org.junit.Rule
+
+abstract class BaseLiveDataTest {
+    lateinit var observer: Observer<Any?>
+
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @Before
+    fun setupObserver() {
+        observer = mock()
+    }
+}

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/CollectionLiveDataTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/CollectionLiveDataTest.kt
@@ -1,9 +1,6 @@
 package org.ccci.gto.android.common.androidx.lifecycle
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
@@ -13,19 +10,13 @@ import org.hamcrest.Matchers.empty
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
-abstract class CollectionLiveDataTests {
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
-
+abstract class CollectionLiveDataTest : BaseLiveDataTest() {
     abstract val liveData: CollectionLiveData<String, out Collection<String>>
-    lateinit var observer: Observer<Any?>
 
     @Before
-    fun setupObserver() {
-        observer = mock()
+    fun setupLiveData() {
         liveData.observeForever(observer)
         reset(observer)
     }
@@ -170,10 +161,10 @@ abstract class CollectionLiveDataTests {
     }
 }
 
-class ListLiveDataTests : CollectionLiveDataTests() {
+class ListLiveDataTest : CollectionLiveDataTest() {
     override val liveData = ListLiveData<String>()
 }
 
-class SetLiveDataTests : CollectionLiveDataTests() {
+class SetLiveDataTest : CollectionLiveDataTest() {
     override val liveData = SetLiveData<String>()
 }

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/EmptyLiveDataTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/EmptyLiveDataTest.kt
@@ -1,20 +1,15 @@
 package org.ccci.gto.android.common.androidx.lifecycle
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.switchMap
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Rule
 import org.junit.Test
 
-class EmptyLiveDataTests {
+class EmptyLiveDataTest : BaseLiveDataTest() {
     private val missing: LiveData<String>? = null
     private val present: LiveData<String> = MutableLiveData("a")
-
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
 
     @Test
     fun testOrEmpty() {

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/LiveDataViewModelObserverTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/LiveDataViewModelObserverTest.kt
@@ -14,7 +14,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class LiveDataViewModelObserver {
+class LiveDataViewModelObserverTest {
     @get:Rule
     val instantTaskRule = InstantTaskExecutorRule()
 

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsCombineWithTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsCombineWithTest.kt
@@ -2,9 +2,12 @@ package org.ccci.gto.android.common.androidx.lifecycle
 
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -27,8 +30,26 @@ class TransformationsCombineWithTest : BaseLiveDataTest() {
         str2.value = "c"
         verify(observer).onChanged(any())
         assertEquals("b, c", combined.value)
+        argumentCaptor<String> {
+            verify(observer).onChanged(capture())
+            assertThat(allValues, contains("b, c"))
+        }
     }
 
+    @Test
+    fun verifySwitchCombineWithObserverCalledOnceOnInitialization() {
+        str1.value = "a"
+        str2.value = "b"
+        str3.value = "c"
+        val combined =
+            str1.switchCombineWith(str2, str3) { a, b, c -> MutableLiveData(listOfNotNull(a, b, c).joinToString()) }
+        combined.observeForever(observer)
+
+        argumentCaptor<String> {
+            verify(observer).onChanged(capture())
+            assertThat(allValues, contains("a, b, c"))
+        }
+    }
     @Test
     fun verifyCombineWith2() {
         val combined = str1.combineWith(str2) { a, b -> listOfNotNull(a, b).joinToString() }
@@ -45,6 +66,10 @@ class TransformationsCombineWithTest : BaseLiveDataTest() {
         str2.value = "c"
         verify(observer, times(2)).onChanged(any())
         assertEquals("b, c", combined.value)
+        argumentCaptor<String> {
+            verify(observer, times(2)).onChanged(capture())
+            assertThat(allValues, contains("b", "b, c"))
+        }
     }
 
     @Test
@@ -69,5 +94,23 @@ class TransformationsCombineWithTest : BaseLiveDataTest() {
         str2.value = "c"
         verify(observer, times(3)).onChanged(any())
         assertEquals("b, c, d", combined.value)
+        argumentCaptor<String> {
+            verify(observer, times(3)).onChanged(capture())
+            assertThat(allValues, contains("b", "b, d", "b, c, d"))
+        }
+    }
+
+    @Test
+    fun verifyCombineWithObserverCalledOnceOnInitialization() {
+        str1.value = "a"
+        str2.value = "b"
+        str3.value = "c"
+        val combined = str1.combineWith(str2, str3) { a, b, c -> listOfNotNull(a, b, c).joinToString() }
+        combined.observeForever(observer)
+
+        argumentCaptor<String> {
+            verify(observer).onChanged(capture())
+            assertThat(allValues, contains("a, b, c"))
+        }
     }
 }

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsCombineWithTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsCombineWithTest.kt
@@ -14,7 +14,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class TransformationsTests {
+class TransformationsCombineWithTest {
     private lateinit var observer: Observer<Any>
 
     @get:Rule

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsCombineWithTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsCombineWithTest.kt
@@ -1,33 +1,18 @@
 package org.ccci.gto.android.common.androidx.lifecycle
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
-class TransformationsCombineWithTest {
-    private lateinit var observer: Observer<Any>
-
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
-
+class TransformationsCombineWithTest : BaseLiveDataTest() {
     private val str1 = MutableLiveData<String>()
     private val str2 = MutableLiveData<String?>()
     private val str3 = MutableLiveData<String?>()
-
-    @Before
-    fun setup() {
-        observer = mock()
-    }
 
     @Test
     fun verifySwitchCombineWith() {

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsFoldTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsFoldTest.kt
@@ -1,0 +1,37 @@
+package org.ccci.gto.android.common.androidx.lifecycle
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.atLeast
+import com.nhaarman.mockitokotlin2.verify
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TransformationsFoldTest : BaseLiveDataTest() {
+    @Test
+    fun verifyLiveDataSwitchFold() {
+        val source = MutableLiveData(listOf(0, 1))
+        val data = listOf(MutableLiveData("a"), MutableLiveData("b"), MutableLiveData("c"), MutableLiveData())
+
+        val liveData = source.switchFold { acc: LiveData<String?>, i ->
+            acc.switchCombineWith(data[i]) { a, b -> MutableLiveData(a.orEmpty() + b.orEmpty()) }
+        }
+        liveData.observeForever(observer)
+        assertEquals("ab", liveData.value)
+        source.value = listOf(0, 1, 2)
+        assertEquals("abc", liveData.value)
+        source.value = listOf(2, 1, 2)
+        assertEquals("cbc", liveData.value)
+        source.value = listOf(3)
+        assertEquals("cbc", liveData.value)
+        data[3].value = "d"
+        assertEquals("d", liveData.value)
+        argumentCaptor<String> {
+            verify(observer, atLeast(4)).onChanged(capture())
+            assertThat(allValues, contains("ab", "abc", "cbc", "d"))
+        }
+    }
+}

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsWithInitialValueTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsWithInitialValueTest.kt
@@ -1,31 +1,16 @@
 package org.ccci.gto.android.common.androidx.lifecycle
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
-class TransformationsWithInitialValueTest {
-    private lateinit var observer: Observer<Any>
-
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
-
-    @Before
-    fun setup() {
-        observer = mock()
-    }
-
+class TransformationsWithInitialValueTest : BaseLiveDataTest() {
     @Test
     fun verifyWithInitialValue() {
         val source = MutableLiveData<String>()

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsWithInitialValueTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/TransformationsWithInitialValueTest.kt
@@ -1,0 +1,64 @@
+package org.ccci.gto.android.common.androidx.lifecycle
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class TransformationsWithInitialValueTest {
+    private lateinit var observer: Observer<Any>
+
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @Before
+    fun setup() {
+        observer = mock()
+    }
+
+    @Test
+    fun verifyWithInitialValue() {
+        val source = MutableLiveData<String>()
+
+        val liveData = source.withInitialValue("a")
+        liveData.observeForever(observer)
+        verify(observer).onChanged(any())
+        assertEquals("a", liveData.value)
+        source.value = "a"
+        assertEquals("a", liveData.value)
+        source.value = "b"
+        assertEquals("b", liveData.value)
+
+        argumentCaptor<String> {
+            verify(observer, times(3)).onChanged(capture())
+            assertThat(allValues, contains("a", "a", "b"))
+        }
+    }
+
+    @Test
+    fun verifyWithInitialValueWhenSourceIsAlreadyInitialized() {
+        val source = MutableLiveData<String>("b")
+
+        val liveData = source.withInitialValue("a")
+        liveData.observeForever(observer)
+        verify(observer).onChanged(any())
+        assertEquals("b", liveData.value)
+        source.value = "c"
+        assertEquals("c", liveData.value)
+
+        argumentCaptor<String> {
+            verify(observer, times(2)).onChanged(capture())
+            assertThat(allValues, contains("b", "c"))
+        }
+    }
+}


### PR DESCRIPTION
adds:
- [x] `LiveData<T>.withInitialValue(value: T): LiveData<T>`
  - Adds an initial value to the LiveData before it loads the actual value.
- [x] `LiveData<Iterable<T>>.switchFold(initial: R, block: (R, T) -> R): LiveData<R>`
  - Folds the Iterable into a `LiveData` accumulator
