### PR TITLE
Closeable XmlPullParser

### DIFF
--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/util/XmlPullParserUtils.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/util/XmlPullParserUtils.java
@@ -2,34 +2,14 @@ package org.ccci.gto.android.common.util;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-import androidx.annotation.NonNull;
-
 public class XmlPullParserUtils {
-    /**
-     * safely call nextText on all versions of Android.
-     *
-     * @deprecated Since v3.0.0, This is no longer necessary since we don't support ICS or earlier.
-     * @param parser the current parser
-     * @return the next text node from the XmlPullParser
-     * @throws IOException
-     * @throws XmlPullParserException
-     * @see <a href="http://android-developers.blogspot.com/2011/12/watch-out-for-xmlpullparsernexttext.html">Watch out for XmlPullParser.nextText()</a>
-     */
-    @Deprecated
-    public static String safeNextText(@NonNull final XmlPullParser parser) throws IOException, XmlPullParserException {
-        final String result = parser.nextText();
-        if (parser.getEventType() != XmlPullParser.END_TAG) {
-            // work around a bug pre-ICS where nextText() didn't consume the text event
-            parser.nextTag();
-        }
-        return result;
-    }
-
     /**
      * Skip the current XML tag (and all of it's children)
      *

--- a/gto-support-util/src/main/java/org/ccci/gto/android/common/util/xmlpull/CloseableXmlPullParser.kt
+++ b/gto-support-util/src/main/java/org/ccci/gto/android/common/util/xmlpull/CloseableXmlPullParser.kt
@@ -1,0 +1,31 @@
+package org.ccci.gto.android.common.util.xmlpull
+
+import android.util.Xml
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserException
+import java.io.Closeable
+import java.io.InputStream
+import java.io.Reader
+
+class CloseableXmlPullParser private constructor(private val parser: XmlPullParser) :
+        XmlPullParser by parser, Closeable {
+    constructor() : this(Xml.newPullParser())
+
+    private var input: Closeable? = null
+
+    @Throws(XmlPullParserException::class)
+    override fun setInput(reader: Reader?) {
+        input = reader
+        parser.setInput(reader)
+    }
+
+    @Throws(XmlPullParserException::class)
+    override fun setInput(inputStream: InputStream?, inputEncoding: String?) {
+        input = inputStream
+        parser.setInput(inputStream, inputEncoding)
+    }
+
+    override fun close() {
+        input?.close()
+    }
+}

--- a/gto-support-util/src/main/java/org/ccci/gto/android/common/util/xmlpull/CloseableXmlPullParser.kt
+++ b/gto-support-util/src/main/java/org/ccci/gto/android/common/util/xmlpull/CloseableXmlPullParser.kt
@@ -20,7 +20,7 @@ class CloseableXmlPullParser private constructor(private val parser: XmlPullPars
     }
 
     @Throws(XmlPullParserException::class)
-    override fun setInput(inputStream: InputStream?, inputEncoding: String?) {
+    override fun setInput(inputStream: InputStream, inputEncoding: String?) {
         input = inputStream
         parser.setInput(inputStream, inputEncoding)
     }

--- a/gto-support-util/src/test/java/org/ccci/gto/android/common/util/xmlpull/CloseableXmlPullParserTest.kt
+++ b/gto-support-util/src/test/java/org/ccci/gto/android/common/util/xmlpull/CloseableXmlPullParserTest.kt
@@ -1,0 +1,77 @@
+package org.ccci.gto.android.common.util.xmlpull
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.InputStream
+import java.io.Reader
+
+@RunWith(AndroidJUnit4::class)
+class CloseableXmlPullParserTest {
+    private lateinit var input: InputStream
+    private lateinit var reader: Reader
+
+    @Before
+    fun setup() {
+        input = mock()
+        reader = mock()
+    }
+
+    @Test
+    fun testInputStreamClose() {
+        val parser = CloseableXmlPullParser()
+        parser.setInput(input, null)
+        parser.close()
+        verify(input).close()
+    }
+
+    @Test
+    fun testInputStreamReplacedNullClose() {
+        val parser = CloseableXmlPullParser()
+        parser.setInput(input, null)
+        parser.setInput(null)
+        parser.close()
+        verify(input, never()).close()
+    }
+
+    @Test
+    fun testInputStreamReplacedReaderClose() {
+        val parser = CloseableXmlPullParser()
+        parser.setInput(input, null)
+        parser.setInput(reader)
+        parser.close()
+        verify(input, never()).close()
+        verify(reader).close()
+    }
+
+    @Test
+    fun testReaderClose() {
+        val parser = CloseableXmlPullParser()
+        parser.setInput(reader)
+        parser.close()
+        verify(reader).close()
+    }
+
+    @Test
+    fun testReaderReplacedNullClose() {
+        val parser = CloseableXmlPullParser()
+        parser.setInput(reader)
+        parser.setInput(null)
+        parser.close()
+        verify(reader, never()).close()
+    }
+
+    @Test
+    fun testReaderReplacedInputStreamClose() {
+        val parser = CloseableXmlPullParser()
+        parser.setInput(reader)
+        parser.setInput(input, null)
+        parser.close()
+        verify(input).close()
+        verify(reader, never()).close()
+    }
+}


### PR DESCRIPTION
a wrapped XmlPullParser that tracks the `InputSource` and closes it when the `XmlPullParser` is closed.