### PR TITLE
Lifecycle aware EventBus.register() extension method

### DIFF
--- a/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Lifecycle.kt
+++ b/gto-support-androidx-lifecycle/src/main/java/org/ccci/gto/android/common/androidx/lifecycle/Lifecycle.kt
@@ -5,12 +5,28 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 
+fun Lifecycle.onStart(block: (owner: LifecycleOwner) -> Unit): LifecycleObserver =
+    LambdaLifecycleObserver(onStart = block).also { addObserver(it) }
+
+fun Lifecycle.onStop(block: (owner: LifecycleOwner) -> Unit): LifecycleObserver =
+    LambdaLifecycleObserver(onStop = block).also { addObserver(it) }
+
 fun Lifecycle.onDestroy(block: (owner: LifecycleOwner) -> Unit): LifecycleObserver =
     LambdaLifecycleObserver(onDestroy = block).also { addObserver(it) }
 
 internal class LambdaLifecycleObserver(
+    private val onStart: ((owner: LifecycleOwner) -> Unit)? = null,
+    private val onStop: ((owner: LifecycleOwner) -> Unit)? = null,
     private val onDestroy: ((owner: LifecycleOwner) -> Unit)? = null
 ) : DefaultLifecycleObserver {
+    override fun onStart(owner: LifecycleOwner) {
+        onStart?.invoke(owner)
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        onStop?.invoke(owner)
+    }
+
     override fun onDestroy(owner: LifecycleOwner) {
         onDestroy?.invoke(owner)
     }

--- a/gto-support-eventbus/build.gradle
+++ b/gto-support-eventbus/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':gto-support-androidx-lifecycle')
     implementation project(':gto-support-core')
     compileOnly project(':gto-support-db')
 

--- a/gto-support-eventbus/build.gradle
+++ b/gto-support-eventbus/build.gradle
@@ -5,4 +5,6 @@ dependencies {
 
     api "org.greenrobot:eventbus:${deps.eventbus}"
     compileOnly "com.jakewharton.timber:timber:${deps.timber}"
+
+    testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
 }

--- a/gto-support-eventbus/src/main/java/org/ccci/gto/android/common/eventbus/lifecycle/EventBus.kt
+++ b/gto-support-eventbus/src/main/java/org/ccci/gto/android/common/eventbus/lifecycle/EventBus.kt
@@ -1,0 +1,21 @@
+package org.ccci.gto.android.common.eventbus.lifecycle
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import org.ccci.gto.android.common.androidx.lifecycle.onStart
+import org.ccci.gto.android.common.androidx.lifecycle.onStop
+import org.greenrobot.eventbus.EventBus
+
+fun EventBus.register(
+    lifecycleOwner: LifecycleOwner,
+    subscriber: Any,
+    atLeast: Lifecycle.State = Lifecycle.State.STARTED
+) {
+    when (atLeast) {
+        Lifecycle.State.STARTED -> {
+            lifecycleOwner.lifecycle.onStart { register(subscriber) }
+            lifecycleOwner.lifecycle.onStop { unregister(subscriber) }
+        }
+        else -> TODO("This state is not supported yet")
+    }
+}

--- a/gto-support-eventbus/src/test/java/org/ccci/gto/android/common/eventbus/lifecycle/EventBusLifecycleRegisterTest.kt
+++ b/gto-support-eventbus/src/test/java/org/ccci/gto/android/common/eventbus/lifecycle/EventBusLifecycleRegisterTest.kt
@@ -1,0 +1,55 @@
+package org.ccci.gto.android.common.eventbus.lifecycle
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import org.greenrobot.eventbus.EventBus
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class EventBusLifecycleRegisterTest {
+    @get:Rule
+    val instantTaskRule = InstantTaskExecutorRule()
+
+    private val lifecycleOwner = object : LifecycleOwner {
+        val lifecycleRegistry = LifecycleRegistry(this)
+        override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    }
+    private lateinit var eventBus: EventBus
+    private val subscriber = Any()
+
+    @Before
+    fun setup() {
+        eventBus = mock()
+    }
+
+    @Test
+    fun verifyRegisterBeforeStart() {
+        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+        eventBus.register(lifecycleOwner, subscriber)
+        verify(eventBus, never()).register(any())
+        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        verify(eventBus).register(subscriber)
+        verify(eventBus, never()).unregister(any())
+        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        verify(eventBus).unregister(any())
+    }
+
+    @Test
+    fun verifyRegisterAfterStart() {
+        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+        eventBus.register(lifecycleOwner, subscriber)
+        verify(eventBus).register(subscriber)
+        verify(eventBus, never()).unregister(any())
+        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        verify(eventBus).unregister(any())
+    }
+}


### PR DESCRIPTION
This method will register/unregister an EventBus subscriber according to the current lifecycle state