### PR TITLE
Utilize TestLifecycleOwner in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ buildscript {
             core                 : '1.3.2',
             databinding          : deps.gradleAndroidPlugin,
             fragment             : '1.2.5',
-            lifecycle            : '2.2.0',
+            lifecycle            : '2.3.0',
             loader               : '1.1.0',
             localBroadcastManager: '1.0.0',
             recyclerView         : '1.1.0',

--- a/gto-support-androidx-lifecycle/build.gradle
+++ b/gto-support-androidx-lifecycle/build.gradle
@@ -11,5 +11,6 @@ dependencies {
 
     testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
     testImplementation "androidx.core:core-ktx:${deps.androidX.core}"
-    testImplementation "androidx.lifecycle:lifecycle-runtime:${deps.androidX.lifecycle}"
+    testImplementation "androidx.lifecycle:lifecycle-runtime-testing:${deps.androidX.lifecycle}"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
 }

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/ConstrainedStateLifecycleOwnerTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/ConstrainedStateLifecycleOwnerTest.kt
@@ -1,28 +1,27 @@
 package org.ccci.gto.android.common.androidx.lifecycle
 
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.testing.TestLifecycleOwner
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.clearInvocations
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class ConstrainedStateLifecycleOwnerTest {
-    private val parentLifecycleOwner = object : LifecycleOwner {
-        val registry = LifecycleRegistry(this)
-        override fun getLifecycle() = registry
-        var currentState
-            get() = registry.currentState
-            set(value) {
-                registry.currentState = value
-            }
-    }
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val parentLifecycleOwner = TestLifecycleOwner(Lifecycle.State.STARTED, TestCoroutineDispatcher())
     private lateinit var observer: DefaultLifecycleObserver
 
     private lateinit var lifecycleOwner: ConstrainedStateLifecycleOwner

--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/LambdaLifecycleObserverTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/LambdaLifecycleObserverTest.kt
@@ -2,22 +2,21 @@ package org.ccci.gto.android.common.androidx.lifecycle
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.testing.TestLifecycleOwner
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.Before
 import org.junit.Test
 
 class LambdaLifecycleObserverTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = TestCoroutineDispatcher())
     private lateinit var lambda: (LifecycleOwner) -> Unit
-
-    private val lifecycleOwner = object : LifecycleOwner {
-        val lifecycleRegistry = LifecycleRegistry(this)
-        override fun getLifecycle(): Lifecycle = lifecycleRegistry
-    }
 
     @Before
     fun setup() {
@@ -26,13 +25,13 @@ class LambdaLifecycleObserverTest {
 
     @Test
     fun testOnDestroy() {
-        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
         lifecycleOwner.lifecycle.onDestroy(lambda)
 
-        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
-        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
         verify(lambda, never()).invoke(any())
-        lifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
         verify(lambda).invoke(eq(lifecycleOwner))
     }
 }

--- a/gto-support-eventbus/build.gradle
+++ b/gto-support-eventbus/build.gradle
@@ -7,4 +7,6 @@ dependencies {
     compileOnly "com.jakewharton.timber:timber:${deps.timber}"
 
     testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
+    testImplementation "androidx.lifecycle:lifecycle-runtime-testing:${deps.androidX.lifecycle}"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
 }


### PR DESCRIPTION
AndroidX Lifecycle 2.3.0 introduces a new `TestLifecycleOwner` which facilitates testing anything dependent on a `Lifecycle`. This PR switches our existing tests to utilize this new `TestLifecycleOwner` class.

This is on hold until Lifecycle 2.3.0 stable is released