### PR TITLE
GT-948 Fix IllegalAccessError when unmarshalling LongSparseParcelableArray

### DIFF
--- a/gto-support-androidx-collection/src/main/java/org/ccci/gto/android/common/androidx/collection/LongSparseBooleanArray.kt
+++ b/gto-support-androidx-collection/src/main/java/org/ccci/gto/android/common/androidx/collection/LongSparseBooleanArray.kt
@@ -2,7 +2,6 @@ package org.ccci.gto.android.common.androidx.collection
 
 import android.os.Parcel
 import android.os.Parcelable
-import androidx.annotation.VisibleForTesting
 import androidx.collection.LongSparseArray
 import kotlinx.android.parcel.Parceler
 import kotlinx.android.parcel.Parcelize
@@ -11,7 +10,6 @@ import kotlinx.android.parcel.Parcelize
 class LongSparseBooleanArray : LongSparseArray<Boolean>(), Parcelable {
     override fun get(key: Long): Boolean = get(key, false)
 
-    @VisibleForTesting
     internal companion object : Parceler<LongSparseBooleanArray> {
         override fun LongSparseBooleanArray.write(parcel: Parcel, flags: Int) {
             val size = size()

--- a/gto-support-androidx-collection/src/main/java/org/ccci/gto/android/common/androidx/collection/LongSparseParcelableArray.kt
+++ b/gto-support-androidx-collection/src/main/java/org/ccci/gto/android/common/androidx/collection/LongSparseParcelableArray.kt
@@ -8,7 +8,7 @@ import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 class LongSparseParcelableArray<T : Parcelable?> : LongSparseArray<T>(), Parcelable {
-    private companion object : Parceler<LongSparseParcelableArray<Parcelable?>> {
+    internal companion object : Parceler<LongSparseParcelableArray<Parcelable?>> {
         override fun LongSparseParcelableArray<Parcelable?>.write(parcel: Parcel, flags: Int) {
             val size = size()
             val keys = LongArray(size)

--- a/gto-support-androidx-collection/src/test/java/org/ccci/gto/android/common/androidx/collection/LongSparseBooleanArrayRobolectricTest.kt
+++ b/gto-support-androidx-collection/src/test/java/org/ccci/gto/android/common/androidx/collection/LongSparseBooleanArrayRobolectricTest.kt
@@ -20,11 +20,16 @@ class LongSparseBooleanArrayRobolectricTest {
             put(Long.MAX_VALUE, true)
         }
 
-        val parcel = Parcel.obtain()
-        orig.writeToParcel(parcel, orig.describeContents())
+        val parceledBytes = Parcel.obtain().run {
+            writeParcelable(orig, 0)
+            marshall()
+        }
 
-        parcel.setDataPosition(0)
-        val created = LongSparseBooleanArray.create(parcel)
+        val created = Parcel.obtain().run {
+            unmarshall(parceledBytes, 0, parceledBytes.size)
+            setDataPosition(0)
+            readParcelable<LongSparseBooleanArray>(this::class.java.classLoader)!!
+        }
 
         assertThat(created.keyIterator().asSequence().toList(), contains(1L, 2003L, Long.MAX_VALUE))
         assertTrue(created.get(1L))

--- a/gto-support-androidx-collection/src/test/java/org/ccci/gto/android/common/androidx/collection/LongSparseParcelableArrayRobolectricTest.kt
+++ b/gto-support-androidx-collection/src/test/java/org/ccci/gto/android/common/androidx/collection/LongSparseParcelableArrayRobolectricTest.kt
@@ -1,0 +1,39 @@
+package org.ccci.gto.android.common.androidx.collection
+
+import android.graphics.Point
+import android.os.Parcel
+import androidx.collection.keyIterator
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LongSparseParcelableArrayRobolectricTest {
+    @Test
+    fun verifyIsParcelable() {
+        val orig = LongSparseParcelableArray<Point>().apply {
+            put(1, Point(1, -1))
+            put(2003, Point(2003, -2003))
+            put(Long.MAX_VALUE, Point(Int.MAX_VALUE, Int.MIN_VALUE))
+        }
+
+        val parceledBytes = Parcel.obtain().run {
+            writeParcelable(orig, 0)
+            marshall()
+        }
+
+        val created = Parcel.obtain().run {
+            unmarshall(parceledBytes, 0, parceledBytes.size)
+            setDataPosition(0)
+            readParcelable<LongSparseParcelableArray<Point>>(this::class.java.classLoader)!!
+        }
+
+        assertThat(created.keyIterator().asSequence().toList(), contains(1L, 2003L, Long.MAX_VALUE))
+        assertEquals(Point(1, -1), created.get(1))
+        assertEquals(Point(2003, -2003), created.get(2003))
+        assertEquals(Point(Int.MAX_VALUE, Int.MIN_VALUE), created.get(Long.MAX_VALUE))
+    }
+}


### PR DESCRIPTION
The companion object can't be private because it causes the Parcel logic to throw an `IllegalAccessError`. I also included a unit test to test the actual marshalling & unmarshalling logic.