### PR TITLE
Kotlin coroutines ReadWriteMutex

### DIFF
--- a/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
+++ b/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
@@ -1,10 +1,12 @@
 package org.ccci.gto.android.common.kotlin.coroutines
 
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 interface ReadWriteMutex {
     val write: Mutex
+    val read: Mutex
 
     suspend fun <T> withReadLock(action: suspend () -> T): T
 }
@@ -16,22 +18,30 @@ private class ReadWriteMutexImpl : ReadWriteMutex {
     private var readers = 0
 
     override val write = Mutex()
-
-    override suspend fun <T> withReadLock(action: suspend () -> T): T {
-        stateMutex.withLock {
-            // first reader should lock the write mutex
-            if (readers == 0) write.lock()
-            readers++
-        }
-
-        try {
-            return action()
-        } finally {
-            stateMutex.withLock {
-                readers--
-                // release the write mutex lock when this is the last reader
-                if (readers == 0) write.unlock()
+    override val read = object : Mutex {
+        override suspend fun lock(owner: Any?) {
+            stateMutex.withLock(owner) {
+                // first reader should lock the write mutex
+                if (readers == 0) write.lock(owner)
+                readers++
             }
         }
+
+        override fun unlock(owner: Any?) {
+            runBlocking {
+                stateMutex.withLock {
+                    readers--
+                    // release the write mutex lock when this is the last reader
+                    if (readers == 0) write.unlock()
+                }
+            }
+        }
+
+        override val isLocked get() = TODO("Not supported")
+        override val onLock get() = TODO("Not supported")
+        override fun holdsLock(owner: Any) = TODO("Not supported")
+        override fun tryLock(owner: Any?) = TODO("Not supported")
     }
+
+    override suspend fun <T> withReadLock(action: suspend () -> T): T = read.withLock { action() }
 }

--- a/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
+++ b/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.sync.withLock
 interface ReadWriteMutex {
     val write: Mutex
 
-    suspend fun <T> withWriteLock(owner: Any? = null, action: suspend () -> T): T
     suspend fun <T> withReadLock(action: suspend () -> T): T
 }
 
@@ -14,10 +13,9 @@ fun ReadWriteMutex(): ReadWriteMutex = ReadWriteMutexImpl()
 
 private class ReadWriteMutexImpl : ReadWriteMutex {
     private val stateMutex = Mutex()
-    override val write = Mutex()
     private var readers = 0
 
-    override suspend fun <T> withWriteLock(owner: Any?, action: suspend () -> T): T = write.withLock(owner) { action() }
+    override val write = Mutex()
 
     override suspend fun <T> withReadLock(action: suspend () -> T): T {
         stateMutex.withLock {

--- a/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
+++ b/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
@@ -27,7 +27,7 @@ internal class ReadWriteMutexImpl : ReadWriteMutex {
                     "Attempt to lock the read mutex more than ${Long.MAX_VALUE} times concurrently"
                 }
                 // first reader should lock the write mutex
-                if (readers.get() == 0L) write.lock(owner)
+                if (readers.get() == 0L) write.lock(readers)
                 readers.incrementAndGet()
             }
         }
@@ -37,7 +37,7 @@ internal class ReadWriteMutexImpl : ReadWriteMutex {
                 check(readers.get() > 0L) { "Attempt to unlock the read mutex when it wasn't locked" }
                 stateMutex.withLock(owner) {
                     // release the write mutex lock when this is the last reader
-                    if (readers.decrementAndGet() == 0L) write.unlock(owner)
+                    if (readers.decrementAndGet() == 0L) write.unlock(readers)
                 }
             }
         }

--- a/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
+++ b/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
@@ -1,0 +1,31 @@
+package org.ccci.gto.android.common.kotlin.coroutines
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class ReadWriteMutex {
+    private val stateMutex = Mutex()
+    private val writeMutex = Mutex()
+    private var readers = 0
+
+    suspend fun <T> withWriteLock(owner: Any? = null, action: suspend () -> T): T =
+        writeMutex.withLock(owner) { action() }
+
+    suspend fun <T> withReadLock(action: suspend () -> T): T {
+        stateMutex.withLock {
+            // first reader should lock the write mutex
+            if (readers == 0) writeMutex.lock()
+            readers++
+        }
+
+        try {
+            return action()
+        } finally {
+            stateMutex.withLock {
+                readers--
+                // release the write mutex lock when this is the last reader
+                if (readers == 0) writeMutex.unlock()
+            }
+        }
+    }
+}

--- a/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
+++ b/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
@@ -7,6 +7,11 @@ import kotlinx.coroutines.sync.withLock
 
 interface ReadWriteMutex {
     val write: Mutex
+
+    /**
+     * Provides a shared read mutex. This Mutex doesn't support the `owner` parameter to debug/prevent deadlocks.
+     * It is also not possible to upgrade a read lock to a write lock without release the read lock first.
+     */
     val read: Mutex
 }
 

--- a/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
+++ b/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
@@ -27,10 +27,10 @@ private class ReadWriteMutexImpl : ReadWriteMutex {
 
         override fun unlock(owner: Any?) {
             runBlocking {
-                stateMutex.withLock {
+                stateMutex.withLock(owner) {
                     readers--
                     // release the write mutex lock when this is the last reader
-                    if (readers == 0) write.unlock()
+                    if (readers == 0) write.unlock(owner)
                 }
             }
         }

--- a/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
+++ b/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
@@ -22,7 +22,7 @@ internal class ReadWriteMutexImpl : ReadWriteMutex {
     override val write = Mutex()
     override val read = object : Mutex {
         override suspend fun lock(owner: Any?) {
-            stateMutex.withLock(owner) {
+            stateMutex.withLock {
                 check(readers.get() < Long.MAX_VALUE) {
                     "Attempt to lock the read mutex more than ${Long.MAX_VALUE} times concurrently"
                 }
@@ -35,7 +35,7 @@ internal class ReadWriteMutexImpl : ReadWriteMutex {
         override fun unlock(owner: Any?) {
             runBlocking {
                 check(readers.get() > 0L) { "Attempt to unlock the read mutex when it wasn't locked" }
-                stateMutex.withLock(owner) {
+                stateMutex.withLock {
                     // release the write mutex lock when this is the last reader
                     if (readers.decrementAndGet() == 0L) write.unlock(readers)
                 }

--- a/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
+++ b/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
@@ -1,7 +1,6 @@
 package org.ccci.gto.android.common.kotlin.coroutines
 
 import androidx.annotation.VisibleForTesting
-import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -16,28 +15,29 @@ fun ReadWriteMutex(): ReadWriteMutex = ReadWriteMutexImpl()
 @VisibleForTesting
 internal class ReadWriteMutexImpl : ReadWriteMutex {
     private val stateMutex = Mutex()
+    private val readerOwner = Any()
     @VisibleForTesting
-    internal val readers = AtomicLong(0)
+    internal var readers = 0L
 
     override val write = Mutex()
     override val read = object : Mutex {
         override suspend fun lock(owner: Any?) {
             stateMutex.withLock {
-                check(readers.get() < Long.MAX_VALUE) {
+                check(readers < Long.MAX_VALUE) {
                     "Attempt to lock the read mutex more than ${Long.MAX_VALUE} times concurrently"
                 }
                 // first reader should lock the write mutex
-                if (readers.get() == 0L) write.lock(readers)
-                readers.incrementAndGet()
+                if (readers == 0L) write.lock(readerOwner)
+                readers++
             }
         }
 
         override fun unlock(owner: Any?) {
             runBlocking {
-                check(readers.get() > 0L) { "Attempt to unlock the read mutex when it wasn't locked" }
                 stateMutex.withLock {
+                    check(readers > 0L) { "Attempt to unlock the read mutex when it wasn't locked" }
                     // release the write mutex lock when this is the last reader
-                    if (readers.decrementAndGet() == 0L) write.unlock(readers)
+                    if (--readers == 0L) write.unlock(readerOwner)
                 }
             }
         }

--- a/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
+++ b/gto-support-kotlin-coroutines/src/main/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutex.kt
@@ -7,8 +7,6 @@ import kotlinx.coroutines.sync.withLock
 interface ReadWriteMutex {
     val write: Mutex
     val read: Mutex
-
-    suspend fun <T> withReadLock(action: suspend () -> T): T
 }
 
 fun ReadWriteMutex(): ReadWriteMutex = ReadWriteMutexImpl()
@@ -42,6 +40,4 @@ private class ReadWriteMutexImpl : ReadWriteMutex {
         override fun holdsLock(owner: Any) = TODO("Not supported")
         override fun tryLock(owner: Any?) = TODO("Not supported")
     }
-
-    override suspend fun <T> withReadLock(action: suspend () -> T): T = read.withLock { action() }
 }

--- a/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -1,0 +1,113 @@
+package org.ccci.gto.android.common.kotlin.coroutines
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.junit.Test
+
+class ReadWriteMutexTest {
+    private val mutex = ReadWriteMutex()
+
+    @Test
+    fun testWriteExclusion() {
+        runBlocking {
+            launch {
+                expect(3)
+                mutex.withWriteLock {
+                    expect(5)
+                }
+            }
+
+            expect(1)
+            mutex.withWriteLock {
+                expect(2)
+                yield()
+                expect(4)
+            }
+        }
+        finish(6)
+    }
+
+    @Test
+    fun testReadShared() {
+        runBlocking {
+            launch {
+                mutex.withReadLock {
+                    yield()
+                    expect(2)
+                    yield()
+                    expect(4)
+                }
+            }
+
+            launch {
+                mutex.withReadLock {
+                    expect(1)
+                    yield()
+                    expect(3)
+                }
+            }
+        }
+        finish(5)
+    }
+
+    @Test
+    fun testWriteLocksRead() {
+        runBlocking {
+            launch {
+                mutex.withReadLock {
+                    expect(2)
+                }
+            }
+
+            mutex.withWriteLock {
+                yield()
+                expect(1)
+            }
+        }
+        finish(3)
+    }
+
+    @Test
+    fun testReadsLockWrite() {
+        runBlocking {
+            launch {
+                expect(3)
+                mutex.withWriteLock {
+                    expect(8)
+                }
+            }
+
+            launch {
+                expect(4)
+                mutex.withReadLock {
+                    expect(5)
+                    yield()
+                    expect(7)
+                }
+            }
+
+            expect(1)
+            mutex.withReadLock {
+                expect(2)
+                yield()
+                expect(6)
+            }
+        }
+        finish(9)
+    }
+
+    private var actionIndex = AtomicInteger(0)
+    private var finished = AtomicBoolean(false)
+    private fun expect(index: Int) {
+        val wasIndex = actionIndex.incrementAndGet()
+        check(index == wasIndex) { "Expecting action index $index but it is actually $wasIndex" }
+    }
+
+    private fun finish(index: Int) {
+        expect(index)
+        check(!finished.getAndSet(true)) { "Should call 'finish(...)' at most once" }
+    }
+}

--- a/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -35,7 +35,7 @@ class ReadWriteMutexTest {
     fun testReadShared() {
         runBlocking {
             launch {
-                mutex.withReadLock {
+                mutex.read.withLock {
                     yield()
                     expect(2)
                     yield()
@@ -44,7 +44,7 @@ class ReadWriteMutexTest {
             }
 
             launch {
-                mutex.withReadLock {
+                mutex.read.withLock {
                     expect(1)
                     yield()
                     expect(3)
@@ -58,7 +58,7 @@ class ReadWriteMutexTest {
     fun testWriteLocksRead() {
         runBlocking {
             launch {
-                mutex.withReadLock {
+                mutex.read.withLock {
                     expect(2)
                 }
             }
@@ -83,7 +83,7 @@ class ReadWriteMutexTest {
 
             launch {
                 expect(4)
-                mutex.withReadLock {
+                mutex.read.withLock {
                     expect(5)
                     yield()
                     expect(7)
@@ -91,7 +91,7 @@ class ReadWriteMutexTest {
             }
 
             expect(1)
-            mutex.withReadLock {
+            mutex.read.withLock {
                 expect(2)
                 yield()
                 expect(6)

--- a/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -98,6 +98,27 @@ class ReadWriteMutexTest {
         finish(9)
     }
 
+    @Test
+    fun testReaderReentrancy() {
+        val owner = Any()
+        runBlocking {
+            expect(1)
+            mutex.read.withLock(owner) {
+                expect(2)
+                mutex.read.withLock(owner) {
+                    expect(3)
+                }
+                expect(4)
+            }
+            expect(5)
+
+            mutex.write.withLock(owner) {
+                expect(6)
+            }
+        }
+        finish(7)
+    }
+
     @Test(expected = IllegalStateException::class)
     fun testReadLockTooManyTimes() {
         runBlocking {

--- a/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -98,6 +98,21 @@ class ReadWriteMutexTest {
         finish(9)
     }
 
+    @Test(expected = IllegalStateException::class)
+    fun testReadLockTooManyTimes() {
+        runBlocking {
+            (mutex as ReadWriteMutexImpl).readers.set(Long.MAX_VALUE - 1)
+            while (true) mutex.read.lock()
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun testInvalidReadUnlock() {
+        runBlocking {
+            mutex.read.unlock()
+        }
+    }
+
     private var actionIndex = 0
     private var finished = false
     private fun expect(index: Int) {

--- a/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -35,23 +35,22 @@ class ReadWriteMutexTest {
     fun testReadShared() {
         runBlocking {
             launch {
+                expect(3)
                 mutex.read.withLock {
-                    yield()
-                    expect(2)
-                    yield()
                     expect(4)
+                    yield()
+                    expect(6)
                 }
             }
 
-            launch {
-                mutex.read.withLock {
-                    expect(1)
-                    yield()
-                    expect(3)
-                }
+            expect(1)
+            mutex.read.withLock {
+                expect(2)
+                yield()
+                expect(5)
             }
         }
-        finish(5)
+        finish(7)
     }
 
     @Test

--- a/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -129,7 +129,7 @@ class ReadWriteMutexTest {
     @Test(expected = IllegalStateException::class)
     fun testReadLockTooManyTimes() {
         runBlocking {
-            (mutex as ReadWriteMutexImpl).readers.set(Long.MAX_VALUE - 1)
+            (mutex as ReadWriteMutexImpl).readers = Long.MAX_VALUE - 1
             while (true) mutex.read.lock()
         }
     }
@@ -159,7 +159,7 @@ class ReadWriteMutexTest {
                 mutex.read.lock()
                 running.set(false)
                 tasks.joinAll()
-                assertEquals(0, (mutex as ReadWriteMutexImpl).readers.get())
+                assertEquals(0, (mutex as ReadWriteMutexImpl).readers)
             }
         }
     }

--- a/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.yield
 import org.junit.Test
 
@@ -15,13 +16,13 @@ class ReadWriteMutexTest {
         runBlocking {
             launch {
                 expect(3)
-                mutex.withWriteLock {
+                mutex.write.withLock {
                     expect(5)
                 }
             }
 
             expect(1)
-            mutex.withWriteLock {
+            mutex.write.withLock {
                 expect(2)
                 yield()
                 expect(4)
@@ -62,7 +63,7 @@ class ReadWriteMutexTest {
                 }
             }
 
-            mutex.withWriteLock {
+            mutex.write.withLock {
                 yield()
                 expect(1)
             }
@@ -75,7 +76,7 @@ class ReadWriteMutexTest {
         runBlocking {
             launch {
                 expect(3)
-                mutex.withWriteLock {
+                mutex.write.withLock {
                     expect(8)
                 }
             }

--- a/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -1,11 +1,10 @@
 package org.ccci.gto.android.common.kotlin.coroutines
 
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.yield
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class ReadWriteMutexTest {
@@ -99,15 +98,16 @@ class ReadWriteMutexTest {
         finish(9)
     }
 
-    private var actionIndex = AtomicInteger(0)
-    private var finished = AtomicBoolean(false)
+    private var actionIndex = 0
+    private var finished = false
     private fun expect(index: Int) {
-        val wasIndex = actionIndex.incrementAndGet()
+        val wasIndex = ++actionIndex
         check(index == wasIndex) { "Expecting action index $index but it is actually $wasIndex" }
     }
 
     private fun finish(index: Int) {
         expect(index)
-        check(!finished.getAndSet(true)) { "Should call 'finish(...)' at most once" }
+        assertFalse("Should call 'finish(...)' at most once", finished)
+        finished = true
     }
 }

--- a/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/java/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -71,17 +71,20 @@ class ReadWriteMutexTest {
 
     @Test
     fun testReadsLockWrite() {
+        val owner1 = Any()
+        val owner2 = Any()
+        val owner3 = Any()
         runBlocking {
             launch {
                 expect(3)
-                mutex.write.withLock {
+                mutex.write.withLock(owner1) {
                     expect(8)
                 }
             }
 
             launch {
                 expect(4)
-                mutex.read.withLock {
+                mutex.read.withLock(owner2) {
                     expect(5)
                     yield()
                     expect(7)
@@ -89,7 +92,7 @@ class ReadWriteMutexTest {
             }
 
             expect(1)
-            mutex.read.withLock {
+            mutex.read.withLock(owner3) {
                 expect(2)
                 yield()
                 expect(6)


### PR DESCRIPTION
Unfortunately Kotlin Coroutines doesn't have a native ReadWriteMutex yet. This implements one with basic functionality as a stop-gap solution until they provide an official one.

a `ReadWriteMutex` should function similarly to a `ReadWriteReentrantLock`.
- write access is exclusive, so only a single process can be writing at a time. 
- While a process is writing no other processes can be reading.
- read access is shared, so any number of readers can share the lock at once.
- while any readers exist, a writer will be blocked

This implementation doesn't address fairness for writers, so it is possible for readers to starve out waiting writers. but my current use-cases for this lock uses write access to perform background maintenance, and the background maintenance isn't critical for functionality, so it's alright if the writers are starved.

Relevant coroutines issue: https://github.com/Kotlin/kotlinx.coroutines/issues/94