### PR TITLE
GT-964 InsetDrawableCompat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects {
             compileSdkVersion 30
 
             defaultConfig {
-                minSdkVersion 16
+                minSdkVersion 19
                 targetSdkVersion 30
 
                 consumerProguardFiles "$rootProject.projectDir/proguard-consumer-jetbrains.pro"

--- a/gto-support-compat/src/main/java/org/ccci/gto/android/common/compat/graphics/drawable/InsetDrawableCompat.kt
+++ b/gto-support-compat/src/main/java/org/ccci/gto/android/common/compat/graphics/drawable/InsetDrawableCompat.kt
@@ -1,0 +1,45 @@
+package org.ccci.gto.android.common.compat.graphics.drawable
+
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.InsetDrawable
+import android.os.Build
+
+class InsetDrawableCompat(
+    drawable: Drawable?,
+    insetLeft: Int,
+    insetTop: Int,
+    insetRight: Int,
+    insetBottom: Int
+) : InsetDrawable(drawable, insetLeft, insetTop, insetRight, insetBottom) {
+    constructor(drawable: Drawable?, inset: Int) : this(drawable, inset, inset, inset, inset)
+
+    private val tmpInsets = Rect()
+    private val insets = Rect()
+    private fun calculateInsets() {
+        if (drawable?.getPadding(tmpInsets) == null) tmpInsets.setEmpty()
+        getPadding(insets)
+        insets.left -= tmpInsets.left
+        insets.top -= tmpInsets.top
+        insets.right -= tmpInsets.right
+        insets.bottom -= tmpInsets.bottom
+    }
+
+    override fun getIntrinsicWidth() = when {
+        // XXX: getIntrinsicWidth() doesn't account for horizontal insets until Lollipop MR1
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1 -> {
+            calculateInsets()
+            drawable?.let { it.intrinsicWidth + insets.left + insets.right } ?: -1
+        }
+        else -> super.getIntrinsicWidth()
+    }
+
+    override fun getIntrinsicHeight() = when {
+        // XXX: getIntrinsicHeight() doesn't account for horizontal insets until Lollipop MR1
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1 -> {
+            calculateInsets()
+            drawable?.let { it.intrinsicHeight + insets.top + insets.bottom } ?: -1
+        }
+        else -> super.getIntrinsicHeight()
+    }
+}

--- a/gto-support-compat/src/test/java/org/ccci/gto/android/common/compat/graphics/drawable/InsetDrawableCompatTest.kt
+++ b/gto-support-compat/src/test/java/org/ccci/gto/android/common/compat/graphics/drawable/InsetDrawableCompatTest.kt
@@ -1,0 +1,33 @@
+package org.ccci.gto.android.common.compat.graphics.drawable
+
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [21, 22])
+class InsetDrawableCompatTest {
+    @Test
+    fun verifyGetIntrinsicWidthAndHeight() {
+        val drawable = mock<Drawable> {
+            on { intrinsicHeight } doReturn 1
+            on { intrinsicWidth } doReturn 2
+            on { getPadding(any()) } doAnswer {
+                it.getArgument<Rect>(0).setEmpty()
+                false
+            }
+        }
+        val insetDrawable = InsetDrawableCompat(drawable, 4, 8, 16, 32)
+
+        assertEquals(1 + 8 + 32, insetDrawable.intrinsicHeight)
+        assertEquals(2 + 4 + 16, insetDrawable.intrinsicWidth)
+    }
+}


### PR DESCRIPTION
`InsetDrawable` does not take insets into account when returning the intrinsic height or width of the drawable. This is causing a rendering difference on older vs newer versions of Android.