### PR TITLE
Revert "Bump flipper from 0.76.0 to 0.77.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
             dagger              : '2.33',
             daggerHilt          : '2.33-beta',
             eventbus            : '3.2.0',
-            facebookFlipper     : '0.77.0',
+            facebookFlipper     : '0.76.0',
             gradleAndroidPlugin : '4.1.2',
             gson                : '2.8.6',
             guava               : '30.1-android',


### PR DESCRIPTION
Reverts CruGlobal/android-gto-support#773