### PR TITLE
GT-1092 Allow synchronous usage of CollectionLiveData

### DIFF
--- a/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/CollectionLiveDataTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/java/org/ccci/gto/android/common/androidx/lifecycle/CollectionLiveDataTest.kt
@@ -1,8 +1,11 @@
 package org.ccci.gto.android.common.androidx.lifecycle
 
+import androidx.arch.core.executor.JunitTaskExecutorRule
+import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.clearInvocations
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
@@ -10,154 +13,175 @@ import org.hamcrest.Matchers.empty
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
-abstract class CollectionLiveDataTest : BaseLiveDataTest() {
+abstract class CollectionLiveDataTest {
+    @get:Rule
+    val rule = JunitTaskExecutorRule(1, false)
+
     abstract val liveData: CollectionLiveData<String, out Collection<String>>
+    lateinit var observer: Observer<Any?>
 
     @Before
     fun setupLiveData() {
-        liveData.observeForever(observer)
-        reset(observer)
+        observer = mock()
+        executeTask(mainThread = true, awaitExecution = true) { liveData.observeForever(observer) }
+        clearInvocations(observer)
     }
 
     @Test
     fun testAdd() {
-        assertTrue(liveData.add("a"))
+        executeTask { assertTrue(liveData.add("a")) }
         verify(observer).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testAddAll() {
-        assertTrue(liveData.addAll(setOf("a", "b", "c")))
+        executeTask { assertTrue(liveData.addAll(setOf("a", "b", "c"))) }
         verify(observer).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a", "b", "c"))
     }
 
     @Test
     fun testAddAllEmpty() {
-        assertFalse(liveData.addAll(emptySet()))
+        executeTask { assertFalse(liveData.addAll(emptySet())) }
         verify(observer, never()).onChanged(any())
         assertThat(liveData.value, empty())
     }
 
     @Test
     fun testPlusAssign() {
-        liveData += "a"
+        executeTask { liveData += "a" }
         verify(observer).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testPlusAssignCollection() {
-        liveData += setOf("a", "b", "c")
+        executeTask { liveData += setOf("a", "b", "c") }
         verify(observer).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a", "b", "c"))
     }
 
     @Test
     fun testPlusAssignCollectionEmpty() {
-        liveData += emptySet()
+        executeTask { liveData += emptySet() }
         verify(observer, never()).onChanged(any())
         assertThat(liveData.value, empty())
     }
 
     @Test
     fun testRemove() {
-        liveData += setOf("a", "b")
-        reset(observer)
+        executeTask { liveData += setOf("a", "b") }
+        clearInvocations(observer)
 
-        assertTrue(liveData.remove("a"))
+        executeTask { assertTrue(liveData.remove("a")) }
         verify(observer).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("b"))
     }
 
     @Test
     fun testRemoveMissing() {
-        liveData += setOf("a")
-        reset(observer)
+        executeTask { liveData += setOf("a") }
+        clearInvocations(observer)
 
-        assertFalse(liveData.remove("b"))
+        executeTask { assertFalse(liveData.remove("b")) }
         verify(observer, never()).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testRemoveAll() {
-        liveData += setOf("a", "b")
-        reset(observer)
+        executeTask { liveData += setOf("a", "b") }
+        clearInvocations(observer)
 
-        assertTrue(liveData.removeAll(setOf("b", "c")))
+        executeTask { assertTrue(liveData.removeAll(setOf("b", "c"))) }
         verify(observer).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testRemoveAllMissing() {
-        liveData += setOf("a")
-        reset(observer)
+        executeTask { liveData += setOf("a") }
+        clearInvocations(observer)
 
-        assertFalse(liveData.removeAll(setOf("b", "c")))
+        executeTask { assertFalse(liveData.removeAll(setOf("b", "c"))) }
         verify(observer, never()).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testMinusAssign() {
-        liveData += setOf("a", "b")
-        reset(observer)
+        executeTask { liveData += setOf("a", "b") }
+        clearInvocations(observer)
 
-        liveData -= "a"
+        executeTask { liveData -= "a" }
         verify(observer).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("b"))
     }
 
     @Test
     fun testMinusAssignMissing() {
-        liveData += setOf("a")
-        reset(observer)
+        executeTask { liveData += setOf("a") }
+        clearInvocations(observer)
 
-        liveData -= "b"
+        executeTask { liveData -= "b" }
         verify(observer, never()).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testMinusAssignCollection() {
-        liveData += setOf("a", "b")
-        reset(observer)
+        executeTask { liveData += setOf("a", "b") }
+        clearInvocations(observer)
 
-        liveData -= setOf("b", "c")
+        executeTask { liveData -= setOf("b", "c") }
         verify(observer).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testMinusAssignCollectionMissing() {
-        liveData += setOf("a")
-        reset(observer)
+        executeTask { liveData += setOf("a") }
+        clearInvocations(observer)
 
-        liveData -= setOf("b", "c")
+        executeTask { liveData -= setOf("b", "c") }
         verify(observer, never()).onChanged(any())
         assertThat(liveData.value, containsInAnyOrder("a"))
     }
 
     @Test
     fun testClear() {
-        liveData += setOf("a")
-        reset(observer)
+        executeTask { liveData += setOf("a") }
+        clearInvocations(observer)
 
-        liveData.clear()
+        executeTask { liveData.clear() }
         verify(observer).onChanged(any())
         assertThat(liveData.value, empty())
     }
 
     @Test
     fun testClearEmpty() {
-        liveData.clear()
+        executeTask { liveData.clear() }
         verify(observer).onChanged(any())
         assertThat(liveData.value, empty())
+    }
+
+    private fun executeTask(mainThread: Boolean = false, awaitExecution: Boolean = true, block: () -> Unit) {
+        try {
+            if (mainThread) {
+                rule.taskExecutor.executeOnMainThread(block)
+            } else {
+                rule.taskExecutor.executeOnDiskIO(block)
+            }
+        } finally {
+            if (awaitExecution) {
+                rule.drainTasks(1)
+                rule.drainTasks(1)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I needed to add a synchronous mode to `CollectionLiveData` so that observers can fire off immediately on an update to the collection.

In the asynchronous mode, the actual update happens on the next frame, and that is when observers would fire off.