### PR TITLE
GT-1119 Prevent Picasso Target from being garbage collected too soon

### DIFF
--- a/gto-support-picasso/build.gradle
+++ b/gto-support-picasso/build.gradle
@@ -1,6 +1,7 @@
 android {
     defaultConfig {
-        consumerProguardFiles 'proguard-consumer.pro'
+        consumerProguardFile 'proguard-consumer.pro'
+        consumerProguardFile 'proguard-consumer-requestcreator.pro'
     }
 
     buildFeatures {

--- a/gto-support-picasso/proguard-consumer-requestcreator.pro
+++ b/gto-support-picasso/proguard-consumer-requestcreator.pro
@@ -1,0 +1,4 @@
+-keepclassmembernames class com.squareup.picasso.RequestCreator {
+    # keep for com.squareup.picasso.RequestCreatorInternalsKt
+    com.squareup.picasso.Picasso picasso;
+}

--- a/gto-support-picasso/src/main/java/com/squareup/picasso/RequestCreatorInternals.kt
+++ b/gto-support-picasso/src/main/java/com/squareup/picasso/RequestCreatorInternals.kt
@@ -1,0 +1,8 @@
+package com.squareup.picasso
+
+import androidx.annotation.VisibleForTesting
+import org.ccci.gto.android.common.util.getDeclaredFieldOrNull
+
+@VisibleForTesting
+internal val picassoField by lazy { getDeclaredFieldOrNull<RequestCreator>("picasso") }
+internal val RequestCreator.picasso get() = picassoField?.get(this) as? Picasso

--- a/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/RequestCreatorCoroutines.kt
+++ b/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/RequestCreatorCoroutines.kt
@@ -5,7 +5,7 @@ import android.graphics.drawable.Drawable
 import com.squareup.picasso.Picasso
 import com.squareup.picasso.RequestCreator
 import com.squareup.picasso.Target
-import java.util.concurrent.atomic.AtomicReference
+import com.squareup.picasso.picasso
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CancellableContinuation
@@ -14,8 +14,11 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 
 suspend fun RequestCreator.getBitmap(): Bitmap = withContext(Dispatchers.Main) {
-    val target = AtomicReference<BitmapContinuationTarget>()
-    suspendCancellableCoroutine { cont -> into(BitmapContinuationTarget(cont).also { target.set(it) }) }
+    suspendCancellableCoroutine { cont ->
+        val target = BitmapContinuationTarget(cont)
+        into(target)
+        cont.invokeOnCancellation { picasso?.cancelRequest(target) }
+    }
 }
 
 private class BitmapContinuationTarget(private val cont: CancellableContinuation<Bitmap>) : Target {

--- a/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/RequestCreatorCoroutines.kt
+++ b/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/RequestCreatorCoroutines.kt
@@ -5,17 +5,20 @@ import android.graphics.drawable.Drawable
 import com.squareup.picasso.Picasso
 import com.squareup.picasso.RequestCreator
 import com.squareup.picasso.Target
-import kotlin.coroutines.Continuation
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 
-suspend fun RequestCreator.getBitmap(): Bitmap =
-    withContext(Dispatchers.Main) { suspendCoroutine { into(BitmapContinuationTarget(it)) } }
+suspend fun RequestCreator.getBitmap(): Bitmap = withContext(Dispatchers.Main) {
+    val target = AtomicReference<BitmapContinuationTarget>()
+    suspendCancellableCoroutine { cont -> into(BitmapContinuationTarget(cont).also { target.set(it) }) }
+}
 
-private class BitmapContinuationTarget(private val cont: Continuation<Bitmap>) : Target {
+private class BitmapContinuationTarget(private val cont: CancellableContinuation<Bitmap>) : Target {
     override fun onPrepareLoad(placeHolderDrawable: Drawable?) = Unit
     override fun onBitmapLoaded(bitmap: Bitmap, from: Picasso.LoadedFrom?) = cont.resume(bitmap)
     override fun onBitmapFailed(e: Exception, errorDrawable: Drawable?) = cont.resumeWithException(e)

--- a/gto-support-picasso/src/test/java/com/squareup/picasso/StubRequestCreator.kt
+++ b/gto-support-picasso/src/test/java/com/squareup/picasso/StubRequestCreator.kt
@@ -1,3 +1,7 @@
 package com.squareup.picasso
 
-open class StubRequestCreator : RequestCreator()
+open class StubRequestCreator(picasso: Picasso? = null) : RequestCreator() {
+    init {
+        picassoField?.set(this, picasso)
+    }
+}

--- a/gto-support-picasso/src/test/java/com/squareup/picasso/StubRequestCreator.kt
+++ b/gto-support-picasso/src/test/java/com/squareup/picasso/StubRequestCreator.kt
@@ -1,0 +1,3 @@
+package com.squareup.picasso
+
+open class StubRequestCreator : RequestCreator()

--- a/gto-support-picasso/src/test/java/org/ccci/gto/android/common/picasso/RequestCreatorTest.kt
+++ b/gto-support-picasso/src/test/java/org/ccci/gto/android/common/picasso/RequestCreatorTest.kt
@@ -9,20 +9,26 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.squareup.picasso.Picasso
 import com.squareup.picasso.RequestCreator
+import com.squareup.picasso.StubRequestCreator
 import com.squareup.picasso.Target
+import java.lang.ref.Reference
+import java.lang.ref.WeakReference
 import java.util.concurrent.Executors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,12 +40,16 @@ class RequestCreatorTest {
     private lateinit var dispatcher: ExecutorCoroutineDispatcher
     private lateinit var testDispatcher: TestCoroutineDispatcher
 
+    private lateinit var bitmap: Bitmap
+
     @Before
     fun setup() {
         request = mock()
         dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
         testDispatcher = TestCoroutineDispatcher()
         Dispatchers.setMain(testDispatcher)
+
+        bitmap = mock()
     }
 
     @After
@@ -50,7 +60,6 @@ class RequestCreatorTest {
 
     @Test
     fun testGetBitmap() {
-        val bitmap = mock<Bitmap>()
         whenever(request.into(any<Target>()))
             .thenAnswer { it.getArgument<Target>(0).onBitmapLoaded(bitmap, Picasso.LoadedFrom.DISK) }
 
@@ -69,7 +78,6 @@ class RequestCreatorTest {
     fun testGetBitmapMainThreadUsage() {
         val thread = HandlerThread("").apply { start() }
         Dispatchers.setMain(Handler(thread.looper).asCoroutineDispatcher())
-        val bitmap = mock<Bitmap>()
         whenever(request.into(any<Target>())).thenAnswer {
             check(thread === Thread.currentThread()) { "Not executing on the Main Thread" }
             it.getArgument<Target>(0).onBitmapLoaded(bitmap, Picasso.LoadedFrom.DISK)
@@ -80,6 +88,29 @@ class RequestCreatorTest {
             request.getBitmap()
         }
         thread.quit()
+    }
+
+    @Test(timeout = 5000)
+    fun `getBitmap() should protect it's target from garbage collection`() {
+        val request = TargetCapturingRequestCreator()
+        runBlocking {
+            val task = launch(Dispatchers.Default) { request.getBitmap() }
+            val ref = request.targets.receive()
+            System.gc()
+            val target = ref.get()
+            if (target == null) task.cancel()
+            assertNotNull(target)
+            target!!.onBitmapLoaded(bitmap, Picasso.LoadedFrom.DISK)
+        }
+    }
+
+    private class TargetCapturingRequestCreator : StubRequestCreator() {
+        val targets = Channel<Reference<Target>>(1)
+
+        override fun into(target: Target) {
+            // into() stores a weak reference of the target
+            assertTrue(targets.offer(WeakReference(target)))
+        }
     }
 
     private class ExpectedException : Exception()


### PR DESCRIPTION
using `.getBitmap()` within GodTools would occasionally fail to complete. I tracked this down to the fact that the bitmap continuation target was being garbage collected early due to Picasso only holding a weak reference to it.

This PR holds a strong reference to the target as  long as it's processing and adds in task cancellation support so that cancelling an in progress getBitmap will try and cancel the request within Picasso as well.