### PR TITLE
GT-1133 Prevent loss of triggered update

### DIFF
--- a/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/PicassoImageView.java
+++ b/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/PicassoImageView.java
@@ -195,6 +195,9 @@ public interface PicassoImageView {
                 return;
             }
 
+            // clear the needs update flag
+            mNeedsUpdate = false;
+
             // create base request
             final RequestCreator update = onCreateUpdate(Picasso.get());
 
@@ -217,9 +220,6 @@ public interface PicassoImageView {
             } else {
                 update.fetch();
             }
-
-            // clear the needs update flag
-            mNeedsUpdate = false;
         }
 
         @NonNull


### PR DESCRIPTION
Picasso has an execution short path that will immediately set an image to the ImageView if it is already loaded into memory.

Because of this it is possible for the last triggered update to not actually fire.

- `triggerUpdate()` is called
  - Picasso sets drawable to ImageView
    - Drawable being updated calls `triggerUpdate()`
      - Execution is currently in a layout pass, so sets `mNeedsUpdate = true`
  - `mNeedsUpdate` is set to `false` before `triggerUpdate()` exits
- `mNeedsUpdate` is currently `false` even though it potentially needs to be run again
