### PR TITLE
GT-1133 Fix updates triggered during layout not executing

### DIFF
--- a/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/PicassoImageView.java
+++ b/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/PicassoImageView.java
@@ -115,6 +115,11 @@ public interface PicassoImageView {
         }
 
         @UiThread
+        public final void setScaleType(@NonNull final ScaleType type) {
+            triggerUpdate();
+        }
+
+        @UiThread
         public final void addTransform(@NonNull final Transformation transformation) {
             mTransforms.add(transformation);
             triggerUpdate();
@@ -135,11 +140,6 @@ public interface PicassoImageView {
                 mSize = new Dimension(w, h);
                 triggerUpdate();
             }
-        }
-
-        @UiThread
-        public final void setScaleType(@NonNull final ScaleType type) {
-            triggerUpdate();
         }
 
         public final void onAttachedToWindow() {

--- a/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/PicassoImageView.java
+++ b/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/PicassoImageView.java
@@ -138,7 +138,8 @@ public interface PicassoImageView {
         public final void onSizeChanged(int w, int h, int oldw, int oldh) {
             if (oldw != w || oldh != h) {
                 mSize = new Dimension(w, h);
-                triggerUpdate();
+                // onSizeChanged() is called during layout, so we need to defer the actual processing
+                triggerUpdate(true);
             }
         }
 
@@ -174,8 +175,19 @@ public interface PicassoImageView {
 
         @UiThread
         protected final void triggerUpdate() {
+            triggerUpdate(false);
+        }
+
+        @UiThread
+        protected final void triggerUpdate(final boolean defer) {
             // short-circuit if we are in edit mode within a development tool
             if (mView.isInEditMode()) {
+                return;
+            }
+
+            // we have requested to defer the update, track that we need an update for later execution
+            if (defer) {
+                mNeedsUpdate = true;
                 return;
             }
 

--- a/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/SimplePicassoImageView.kt
+++ b/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/view/SimplePicassoImageView.kt
@@ -54,16 +54,6 @@ open class SimplePicassoImageView : ImageView, PicassoImageView {
     override fun setTransforms(transforms: List<Transformation?>?) = helper.setTransforms(transforms)
     override fun toggleBatchUpdates(enable: Boolean) = helper.toggleBatchUpdates(enable)
 
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
-        helper.onAttachedToWindow()
-    }
-
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-        helper.onDetachedFromWindow()
-    }
-
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
         helper.onSizeChanged(w, h, oldw, oldh)


### PR DESCRIPTION
Updating the image set to the ImageView in the middle of a layout process may not display until a subsequent layout is triggered.

To avoid this behavior we now defer any triggered updates until the layout process isn't running.