### PR TITLE
upgrade to Okta OIDC 1.0.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
             moshi               : '1.12.0',
             okhttp3             : '4.9.1',
             okio                : '2.10.0',
-            okta                : '1.0.18',
+            okta                : '1.0.20',
             picasso             : '2.8',
             playCore            : '1.10.0',
             powermock           : '2.0.9',

--- a/gto-support-okta/build.gradle
+++ b/gto-support-okta/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation project(':gto-support-base')
     implementation project(':gto-support-util')
 
-    api "com.okta.android:oidc-androidx:${deps.okta}"
+    api "com.okta.android:okta-oidc-android:${deps.okta}"
 
     // region Coroutines
     compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"

--- a/testing/gto-support-okta/build.gradle
+++ b/testing/gto-support-okta/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    api "com.okta.android:oidc-androidx:${deps.okta}"
+    api "com.okta.android:okta-oidc-android:${deps.okta}"
 }


### PR DESCRIPTION
Okta changed the artifact name when transitioning from 1.0.18 to 1.0.19
