### PR TITLE
Revert "command line lint is broke for RestrictTo LIBRARY_GROUP, so suppress lint warnings for now"

### DIFF
--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Dao.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Dao.kt
@@ -1,6 +1,5 @@
 package org.ccci.gto.android.common.db
 
-import android.annotation.SuppressLint
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
 import androidx.annotation.RestrictTo
@@ -112,9 +111,7 @@ inline fun <reified T : Any> Dao.find(vararg key: Any) = find(T::class.java, *ke
 inline fun <T : Any> Query<T>.get(dao: Dao) = dao.get(this)
 inline fun Query<*>.getCursor(dao: Dao) = dao.getCursor(this)
 
-@SuppressLint("RestrictedApi")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 inline fun <reified T : Any> Dao.getService() = getService(T::class.java)
-@SuppressLint("RestrictedApi")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 inline fun <reified T : Any> Dao.getService(noinline defaultValue: () -> T) = getService(T::class.java, defaultValue)

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Join.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Join.kt
@@ -1,13 +1,11 @@
 package org.ccci.gto.android.common.db
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@SuppressLint("SupportAnnotationUsage")
 data class Join<S : Any, T : Any> private constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val target: Table<T>,
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val base: Join<S, *>? = null,

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Query.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Query.kt
@@ -1,11 +1,9 @@
 package org.ccci.gto.android.common.db
 
-import android.annotation.SuppressLint
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import org.ccci.gto.android.common.db.AbstractDao.Companion.bindValues
 
-@SuppressLint("SupportAnnotationUsage")
 data class Query<T : Any> private constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     val table: Table<T>,

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Table.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Table.kt
@@ -1,13 +1,11 @@
 package org.ccci.gto.android.common.db
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@SuppressLint("SupportAnnotationUsage")
 data class Table<T : Any> internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val type: Class<T>,
     private val alias: String? = null,


### PR DESCRIPTION
This reverts commit df36d8ae780fca243328c4de30366c13bf02a094.

Relevant bug report: https://issuetracker.google.com/issues/194100378