### PR TITLE
cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,8 +115,6 @@ configure(subprojects.findAll { it.path.contains("gto-support") }) {
                 targetSdkVersion 30
 
                 consumerProguardFiles "$rootProject.projectDir/proguard-consumer-jetbrains.pro"
-
-                testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
             }
 
             compileOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -119,9 +119,6 @@ configure(subprojects.findAll { it.path.contains("gto-support") }) {
                 testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
             }
 
-            adbOptions {
-               timeOutInMs 600000
-            }
             compileOptions {
                 sourceCompatibility JavaVersion.VERSION_1_8
                 targetCompatibility JavaVersion.VERSION_1_8

--- a/gto-support-androidx-room/src/main/java/org/ccci/gto/android/common/androidx/room/converter/LocaleConverter.kt
+++ b/gto-support-androidx-room/src/main/java/org/ccci/gto/android/common/androidx/room/converter/LocaleConverter.kt
@@ -2,14 +2,13 @@ package org.ccci.gto.android.common.androidx.room.converter
 
 import androidx.room.TypeConverter
 import java.util.Locale
-import org.ccci.gto.android.common.compat.util.LocaleCompat
 
 object LocaleConverter {
     @JvmStatic
     @TypeConverter
-    fun toLocale(tag: String?) = tag?.let { LocaleCompat.forLanguageTag(it) }
+    fun toLocale(tag: String?) = tag?.let { Locale.forLanguageTag(it) }
 
     @JvmStatic
     @TypeConverter
-    fun toString(locale: Locale?) = locale?.let { LocaleCompat.toLanguageTag(it) }
+    fun toString(locale: Locale?) = locale?.toLanguageTag()
 }

--- a/gto-support-api-retrofit2/src/main/java/org/ccci/gto/android/common/api/retrofit2/converter/LocaleConverters.java
+++ b/gto-support-api-retrofit2/src/main/java/org/ccci/gto/android/common/api/retrofit2/converter/LocaleConverters.java
@@ -2,8 +2,6 @@ package org.ccci.gto.android.common.api.retrofit2.converter;
 
 import androidx.annotation.Nullable;
 
-import org.ccci.gto.android.common.compat.util.LocaleCompat;
-
 import java.io.IOException;
 import java.util.Locale;
 
@@ -15,7 +13,7 @@ class LocaleConverters {
 
         @Override
         public String convert(@Nullable final Locale locale) throws IOException {
-            return locale != null ? LocaleCompat.toLanguageTag(locale) : null;
+            return locale != null ? locale.toLanguageTag() : null;
         }
     }
 }

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/app/SimpleLoaderCallbacks.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/app/SimpleLoaderCallbacks.java
@@ -6,6 +6,10 @@ import androidx.annotation.Nullable;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public abstract class SimpleLoaderCallbacks<D> implements LoaderManager.LoaderCallbacks<D> {
     @Override
     public void onLoaderReset(@NonNull final Loader<D> loader) {

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/AsyncTaskBroadcastReceiverLoader.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/AsyncTaskBroadcastReceiverLoader.java
@@ -6,6 +6,10 @@ import android.content.IntentFilter;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public abstract class AsyncTaskBroadcastReceiverLoader<D> extends CachingAsyncTaskLoader<D>
         implements BroadcastReceiverLoaderHelper.Interface {
     private final BroadcastReceiverLoaderHelper mHelper;

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/AsyncTaskSharedPreferencesChangeLoader.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/AsyncTaskSharedPreferencesChangeLoader.java
@@ -5,6 +5,10 @@ import android.content.SharedPreferences;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public abstract class AsyncTaskSharedPreferencesChangeLoader<D> extends CachingAsyncTaskLoader<D>
         implements SharedPreferencesChangeLoaderHelper.Interface {
     private final SharedPreferencesChangeLoaderHelper mHelper;

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/BroadcastReceiverLoaderHelper.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/BroadcastReceiverLoaderHelper.java
@@ -9,6 +9,10 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import java.util.ArrayList;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public final class BroadcastReceiverLoaderHelper {
     public interface Interface {
         void addIntentFilter(@NonNull IntentFilter filter);

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/CachingAsyncTaskLoader.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/CachingAsyncTaskLoader.java
@@ -6,6 +6,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.loader.content.AsyncTaskLoader;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public abstract class CachingAsyncTaskLoader<D> extends AsyncTaskLoader<D> {
     @Nullable
     private D mData;

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/CursorBroadcastReceiverLoader.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/CursorBroadcastReceiverLoader.java
@@ -6,6 +6,10 @@ import android.content.IntentFilter;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public abstract class CursorBroadcastReceiverLoader extends SimpleCursorLoader
         implements BroadcastReceiverLoaderHelper.Interface {
     @NonNull

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/LoaderBroadcastReceiver.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/LoaderBroadcastReceiver.java
@@ -6,6 +6,10 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.loader.content.Loader;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public class LoaderBroadcastReceiver extends BroadcastReceiver {
     @NonNull
     private final Loader mLoader;

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/SharedPreferencesChangeLoaderHelper.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/SharedPreferencesChangeLoaderHelper.java
@@ -8,6 +8,10 @@ import androidx.loader.content.Loader;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public final class SharedPreferencesChangeLoaderHelper {
     public interface Interface {
         void addPreferenceKey(@Nullable String key);

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/SimpleCursorLoader.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/SimpleCursorLoader.java
@@ -7,6 +7,10 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 import androidx.loader.content.CursorLoader;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public abstract class SimpleCursorLoader extends CursorLoader {
     public SimpleCursorLoader(@NonNull final Context context) {
         super(context);

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/SwipeRefreshLayoutBroadcastReceiverHelper.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/support/v4/content/SwipeRefreshLayoutBroadcastReceiverHelper.java
@@ -11,6 +11,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public class SwipeRefreshLayoutBroadcastReceiverHelper {
     SwipeRefreshLayout mRefreshLayout = null;
 

--- a/gto-support-db-stream/src/main/java/org/ccci/gto/android/common/db/StreamDao.kt
+++ b/gto-support-db-stream/src/main/java/org/ccci/gto/android/common/db/StreamDao.kt
@@ -7,10 +7,4 @@ import com.annimon.stream.Stream
  */
 interface StreamDao : Dao {
     fun <T : Any> streamCompat(query: Query<T>): Stream<T> = Stream.of(get(query))
-
-    object StreamHelper {
-        @JvmStatic
-        @Deprecated("Since v3.4.0, use default implementation of streamCompat instead.")
-        fun <T : Any> stream(dao: Dao, query: Query<T>): Stream<T> = Stream.of(dao.get(query))
-    }
 }

--- a/gto-support-db-stream/src/main/java/org/ccci/gto/android/common/db/StreamDao.kt
+++ b/gto-support-db-stream/src/main/java/org/ccci/gto/android/common/db/StreamDao.kt
@@ -6,7 +6,6 @@ import com.annimon.stream.Stream
  * Stream DAO interface relying on backwards compatible Lightweight Stream API.
  */
 interface StreamDao : Dao {
-    @JvmDefault
     fun <T : Any> streamCompat(query: Query<T>): Stream<T> = Stream.of(get(query))
 
     object StreamHelper {

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/AbstractDao.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/AbstractDao.kt
@@ -11,7 +11,6 @@ import androidx.collection.SimpleArrayMap
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executor
-import org.ccci.gto.android.common.compat.util.LocaleCompat
 import org.ccci.gto.android.common.db.CommonTables.LastSyncTable
 import org.ccci.gto.android.common.util.ArrayUtils
 import org.ccci.gto.android.common.util.database.getLong
@@ -33,7 +32,7 @@ abstract class AbstractDao(private val helper: SQLiteOpenHelper) : Dao {
                 is String -> it
                 is Boolean -> if (it) "1" else "0"
                 is Date -> it.time.toString()
-                is Locale -> LocaleCompat.toLanguageTag(it)
+                is Locale -> it.toLanguageTag()
                 else -> it.toString()
             }
         }.toTypedArray()

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/AbstractMapper.java
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/AbstractMapper.java
@@ -6,7 +6,6 @@ import android.database.Cursor;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.ccci.gto.android.common.compat.util.LocaleCompat;
 import org.ccci.gto.android.common.db.util.CursorUtils;
 import org.ccci.gto.android.common.util.database.CursorKt;
 import org.json.JSONArray;
@@ -95,7 +94,7 @@ public abstract class AbstractMapper<T> implements Mapper<T> {
 
     @Nullable
     protected final String serialize(@Nullable final Locale locale) {
-        return locale != null ? LocaleCompat.toLanguageTag(locale) : null;
+        return locale != null ? locale.toLanguageTag() : null;
     }
 
     /**

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Dao.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Dao.kt
@@ -22,11 +22,9 @@ interface Dao {
     @WorkerThread
     fun <T : Any> get(query: Query<T>): List<T>
 
-    @JvmDefault
     @WorkerThread
     fun getCursor(clazz: Class<*>) = getCursor(Query.select(clazz))
 
-    @JvmDefault
     @WorkerThread
     fun getCursor(clazz: Class<*>, whereClause: String?, whereBindValues: Array<String>?, orderBy: String?) =
         getCursor(Query.select(clazz).where(whereClause, *whereBindValues.orEmpty()).orderBy(orderBy))
@@ -36,14 +34,12 @@ interface Dao {
     // endregion Read-Only
 
     // region Read-Write
-    @JvmDefault
     @WorkerThread
     fun <T : Any> insert(obj: T) = insert(obj, SQLiteDatabase.CONFLICT_NONE)
 
     @WorkerThread
     fun <T : Any> insert(obj: T, conflictAlgorithm: Int): Long
 
-    @JvmDefault
     @WorkerThread
     fun <T : Any> update(obj: T, where: Expression?, vararg projection: String): Int =
         update(obj, where, SQLiteDatabase.CONFLICT_NONE, *projection)
@@ -66,7 +62,6 @@ interface Dao {
     @WorkerThread
     fun <T : Any> update(obj: T, where: Expression?, conflictAlgorithm: Int, vararg projection: String): Int
 
-    @JvmDefault
     @WorkerThread
     fun updateOrInsert(obj: Any, vararg projection: String) =
         updateOrInsert(obj, SQLiteDatabase.CONFLICT_NONE, *projection)

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Join.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Join.kt
@@ -19,10 +19,6 @@ data class Join<S : Any, T : Any> private constructor(
         val NO_JOINS = emptyArray<Join<*, *>>()
 
         @JvmStatic
-        @Deprecated("Since v3.3.0, use source.join() instead", ReplaceWith("source.join(target)"))
-        fun <S : Any, T : Any> create(source: Table<S>, target: Table<T>) = source.join(target)
-
-        @JvmStatic
         fun <S : Any, T : Any> create(target: Table<T>) = Join<S, T>(target = target)
     }
 

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Join.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Join.kt
@@ -3,8 +3,8 @@ package org.ccci.gto.android.common.db
 import android.annotation.SuppressLint
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @SuppressLint("SupportAnnotationUsage")

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Table.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Table.kt
@@ -3,8 +3,8 @@ package org.ccci.gto.android.common.db
 import android.annotation.SuppressLint
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @SuppressLint("SupportAnnotationUsage")

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/support/v4/content/DaoCursorBroadcastReceiverLoader.java
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/support/v4/content/DaoCursorBroadcastReceiverLoader.java
@@ -1,19 +1,23 @@
 package org.ccci.gto.android.common.db.support.v4.content;
 
+import static org.ccci.gto.android.common.db.AbstractDao.ARG_WHERE;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.IntentFilter;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.ccci.gto.android.common.db.AbstractDao;
 import org.ccci.gto.android.common.db.Table;
 import org.ccci.gto.android.common.support.v4.content.BroadcastReceiverLoaderHelper;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-import static org.ccci.gto.android.common.db.AbstractDao.ARG_WHERE;
-
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public class DaoCursorBroadcastReceiverLoader<T> extends DaoCursorLoader<T>
         implements BroadcastReceiverLoaderHelper.Interface {
     @NonNull

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/support/v4/content/DaoCursorLoader.java
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/support/v4/content/DaoCursorLoader.java
@@ -1,8 +1,18 @@
 package org.ccci.gto.android.common.db.support.v4.content;
 
+import static org.ccci.gto.android.common.db.AbstractDao.ARG_DISTINCT;
+import static org.ccci.gto.android.common.db.AbstractDao.ARG_JOINS;
+import static org.ccci.gto.android.common.db.AbstractDao.ARG_ORDER_BY;
+import static org.ccci.gto.android.common.db.AbstractDao.ARG_PROJECTION;
+import static org.ccci.gto.android.common.db.AbstractDao.ARG_WHERE;
+
 import android.content.Context;
 import android.database.Cursor;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 
 import org.ccci.gto.android.common.db.AbstractDao;
 import org.ccci.gto.android.common.db.Expression;
@@ -13,16 +23,10 @@ import org.ccci.gto.android.common.db.Table;
 import org.ccci.gto.android.common.support.v4.content.SimpleCursorLoader;
 import org.ccci.gto.android.common.util.os.BundleUtils;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.WorkerThread;
-
-import static org.ccci.gto.android.common.db.AbstractDao.ARG_DISTINCT;
-import static org.ccci.gto.android.common.db.AbstractDao.ARG_JOINS;
-import static org.ccci.gto.android.common.db.AbstractDao.ARG_ORDER_BY;
-import static org.ccci.gto.android.common.db.AbstractDao.ARG_PROJECTION;
-import static org.ccci.gto.android.common.db.AbstractDao.ARG_WHERE;
-
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public class DaoCursorLoader<T> extends SimpleCursorLoader {
     @NonNull
     protected final AbstractDao mDao;

--- a/gto-support-eventbus/src/main/java/org/ccci/gto/android/common/eventbus/content/CachingAsyncTaskEventBusLoader.java
+++ b/gto-support-eventbus/src/main/java/org/ccci/gto/android/common/eventbus/content/CachingAsyncTaskEventBusLoader.java
@@ -2,13 +2,17 @@ package org.ccci.gto.android.common.eventbus.content;
 
 import android.content.Context;
 
-import org.ccci.gto.android.common.support.v4.content.CachingAsyncTaskLoader;
-import org.greenrobot.eventbus.EventBus;
-
 import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.ccci.gto.android.common.support.v4.content.CachingAsyncTaskLoader;
+import org.greenrobot.eventbus.EventBus;
+
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public abstract class CachingAsyncTaskEventBusLoader<D> extends CachingAsyncTaskLoader<D>
         implements EventBusLoaderHelper.Interface {
     @NonNull

--- a/gto-support-eventbus/src/main/java/org/ccci/gto/android/common/eventbus/content/CursorEventBusLoader.java
+++ b/gto-support-eventbus/src/main/java/org/ccci/gto/android/common/eventbus/content/CursorEventBusLoader.java
@@ -2,13 +2,17 @@ package org.ccci.gto.android.common.eventbus.content;
 
 import android.content.Context;
 
-import org.ccci.gto.android.common.support.v4.content.SimpleCursorLoader;
-import org.greenrobot.eventbus.EventBus;
-
 import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.ccci.gto.android.common.support.v4.content.SimpleCursorLoader;
+import org.greenrobot.eventbus.EventBus;
+
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public abstract class CursorEventBusLoader extends SimpleCursorLoader implements EventBusLoaderHelper.Interface {
     @NonNull
     private final EventBusLoaderHelper mHelper;

--- a/gto-support-eventbus/src/main/java/org/ccci/gto/android/common/eventbus/content/DaoCursorEventBusLoader.java
+++ b/gto-support-eventbus/src/main/java/org/ccci/gto/android/common/eventbus/content/DaoCursorEventBusLoader.java
@@ -3,14 +3,18 @@ package org.ccci.gto.android.common.eventbus.content;
 import android.content.Context;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.ccci.gto.android.common.db.AbstractDao;
 import org.ccci.gto.android.common.db.Table;
 import org.ccci.gto.android.common.db.support.v4.content.DaoCursorLoader;
 import org.greenrobot.eventbus.EventBus;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
+/**
+ * @deprecated Since v3.9.0, use LiveData & coroutines to asynchronously load data for a UI.
+ */
+@Deprecated
 public class DaoCursorEventBusLoader<T> extends DaoCursorLoader<T> implements EventBusLoaderHelper.Interface {
     private final EventBusLoaderHelper mHelper;
 

--- a/gto-support-jsonapi/src/main/java/org/ccci/gto/android/common/jsonapi/converter/LocaleTypeConverter.kt
+++ b/gto-support-jsonapi/src/main/java/org/ccci/gto/android/common/jsonapi/converter/LocaleTypeConverter.kt
@@ -1,11 +1,9 @@
 package org.ccci.gto.android.common.jsonapi.converter
 
 import java.util.Locale
-import org.ccci.gto.android.common.compat.util.LocaleCompat.forLanguageTag
-import org.ccci.gto.android.common.compat.util.LocaleCompat.toLanguageTag
 
 object LocaleTypeConverter : TypeConverter<Locale> {
     override fun supports(clazz: Class<*>) = Locale::class.java == clazz
-    override fun toString(value: Locale?) = value?.let { toLanguageTag(it) }
-    override fun fromString(value: String?) = value?.let { forLanguageTag(it) }
+    override fun toString(value: Locale?) = value?.toLanguageTag()
+    override fun fromString(value: String?) = value?.let { Locale.forLanguageTag(it) }
 }

--- a/gto-support-moshi/src/main/java/org/ccci/gto/android/common/moshi/adapter/LocaleJsonAdapter.kt
+++ b/gto-support-moshi/src/main/java/org/ccci/gto/android/common/moshi/adapter/LocaleJsonAdapter.kt
@@ -3,12 +3,11 @@ package org.ccci.gto.android.common.moshi.adapter
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import java.util.Locale
-import org.ccci.gto.android.common.compat.util.LocaleCompat
 
 object LocaleJsonAdapter {
     @ToJson
-    fun toJson(locale: Locale?) = locale?.let { LocaleCompat.toLanguageTag(locale) }
+    fun toJson(locale: Locale?) = locale?.toLanguageTag()
 
     @FromJson
-    fun fromJson(tag: String?) = tag?.let { LocaleCompat.forLanguageTag(tag) }
+    fun fromJson(tag: String?) = tag?.let { Locale.forLanguageTag(tag) }
 }

--- a/gto-support-util/src/main/java/org/ccci/gto/android/common/util/Locale.kt
+++ b/gto-support-util/src/main/java/org/ccci/gto/android/common/util/Locale.kt
@@ -1,7 +1,6 @@
 package org.ccci.gto.android.common.util
 
 import java.util.Locale
-import org.ccci.gto.android.common.compat.util.LocaleCompat
 
 fun Locale.getOptionalDisplayName(inLocale: Locale? = null) = when {
     inLocale != null && getDisplayLanguage(inLocale) == language -> null
@@ -11,4 +10,4 @@ fun Locale.getOptionalDisplayName(inLocale: Locale? = null) = when {
 }
 
 @JvmSynthetic
-fun String.toLocale() = LocaleCompat.forLanguageTag(this)
+fun String.toLocale() = Locale.forLanguageTag(this)

--- a/gto-support-util/src/main/java/org/ccci/gto/android/common/util/os/BundleUtils.kt
+++ b/gto-support-util/src/main/java/org/ccci/gto/android/common/util/os/BundleUtils.kt
@@ -5,7 +5,6 @@ package org.ccci.gto.android.common.util.os
 import android.os.Bundle
 import android.os.Parcelable
 import java.util.Locale
-import org.ccci.gto.android.common.compat.util.LocaleCompat
 import org.jetbrains.annotations.Contract
 
 // region Enums
@@ -29,14 +28,12 @@ inline fun <reified T : Enum<T>> Bundle.getEnum(key: String?, defValue: T? = nul
 // endregion Enums
 
 // region Locales
-
-fun Bundle.putLocale(key: String?, locale: Locale?) =
-    putString(key, if (locale != null) LocaleCompat.toLanguageTag(locale) else null)
+fun Bundle.putLocale(key: String?, locale: Locale?) = putString(key, locale?.toLanguageTag())
 
 @JvmOverloads
 @Contract("_, _, !null -> !null")
 fun Bundle.getLocale(key: String?, defValue: Locale? = null) =
-    getString(key)?.let { LocaleCompat.forLanguageTag(it) } ?: defValue
+    getString(key)?.let { Locale.forLanguageTag(it) } ?: defValue
 
 /**
  * Store an array of Locales in the provided Bundle
@@ -48,7 +45,7 @@ fun Bundle.getLocale(key: String?, defValue: Locale? = null) =
  */
 @JvmOverloads
 fun Bundle.putLocaleArray(key: String?, locales: Array<Locale?>?, singleString: Boolean = false) {
-    val tags = locales?.map { it?.let { LocaleCompat.toLanguageTag(it) } }?.toTypedArray()
+    val tags = locales?.map { it?.toLanguageTag() }?.toTypedArray()
 
     if (singleString) {
         putString(key, tags?.joinToString(","))
@@ -59,8 +56,7 @@ fun Bundle.putLocaleArray(key: String?, locales: Array<Locale?>?, singleString: 
 
 fun Bundle.getLocaleArray(key: String?) =
     (getStringArray(key) ?: getString(key)?.split(",")?.toTypedArray())
-        ?.map { it?.let { LocaleCompat.forLanguageTag(it) } }?.toTypedArray()
-
+        ?.map { it?.let { Locale.forLanguageTag(it) } }?.toTypedArray()
 // endregion Locales
 
 // region Parcelables

--- a/gto-support-util/src/test/java/org/ccci/gto/android/common/util/content/ContextTest.kt
+++ b/gto-support-util/src/test/java/org/ccci/gto/android/common/util/content/ContextTest.kt
@@ -10,7 +10,6 @@ import org.ccci.gto.android.common.util.os.toTypedArray
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.arrayContaining
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
@@ -30,15 +29,7 @@ class ContextTest {
     }
 
     @Test
-    fun verifyLocalizeSdk16() {
-        assumeTrue(Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1)
-
-        assertSame(context, context.localize(Locale.FRENCH))
-    }
-
-    @Test
-    fun verifyLocalizeSdk17() {
-        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+    fun verifyLocalizeSdk21() {
         assumeTrue(Build.VERSION.SDK_INT < Build.VERSION_CODES.N)
 
         context.resources.configuration.setLocale(Locale.ENGLISH)


### PR DESCRIPTION
- switch to the new Parcelize annotations
- remove more deprecated `@JvmDefault` annotations
- adb timeout setting is no longer necessary
- we no longer run connected tests, so the testInstrumentationRunner is not necessary
- stop using LocaleCompat
- remove unused SDK16 test
