### PR TITLE
GT-1136 add a Picasso target for MaterialButton icons

### DIFF
--- a/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/material/button/MaterialButtonIconTarget.kt
+++ b/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/material/button/MaterialButtonIconTarget.kt
@@ -1,0 +1,22 @@
+package org.ccci.gto.android.common.picasso.material.button
+
+import android.graphics.drawable.Drawable
+import com.google.android.material.button.MaterialButton
+import org.ccci.gto.android.common.picasso.BaseViewTarget
+import org.ccci.gto.android.common.picasso.R
+
+class MaterialButtonIconTarget private constructor(button: MaterialButton) : BaseViewTarget<MaterialButton>(button) {
+    init {
+        view.setTag(R.id.picasso_materialButtonIconTarget, this)
+    }
+
+    companion object {
+        fun of(button: MaterialButton) =
+            button.getTag(R.id.picasso_materialButtonIconTarget) as? MaterialButtonIconTarget
+                ?: MaterialButtonIconTarget(button)
+    }
+
+    public override fun updateDrawable(drawable: Drawable?) {
+        view.icon = drawable
+    }
+}

--- a/gto-support-picasso/src/main/res/values/ids.xml
+++ b/gto-support-picasso/src/main/res/values/ids.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="picasso_chipIconTarget" type="id" />
+    <item name="picasso_materialButtonIconTarget" type="id" />
     <item name="picasso_textViewDrawableStartTarget" type="id" />
     <item name="picasso_textViewDrawableEndTarget" type="id" />
 </resources>

--- a/gto-support-picasso/src/test/java/org/ccci/gto/android/common/picasso/material/button/MaterialButtonIconTargetTest.kt
+++ b/gto-support-picasso/src/test/java/org/ccci/gto/android/common/picasso/material/button/MaterialButtonIconTargetTest.kt
@@ -1,0 +1,53 @@
+package org.ccci.gto.android.common.picasso.material.button
+
+import android.graphics.drawable.Drawable
+import com.google.android.material.button.MaterialButton
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.reset
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+class MaterialButtonIconTargetTest {
+    private lateinit var button: MaterialButton
+    private lateinit var target: MaterialButtonIconTarget
+    private lateinit var drawable: Drawable
+
+    @Before
+    fun setup() {
+        button = mock()
+        target = MaterialButtonIconTarget.of(button)
+        drawable = mock()
+        reset(button)
+    }
+
+    @Test
+    fun verifyTargetIsSaved() {
+        val target = MaterialButtonIconTarget.of(button)
+        verify(button).setTag(any(), eq(target))
+    }
+
+    @Test
+    fun verifyTargetIsReused() {
+        whenever(button.getTag(any())).thenReturn(target)
+
+        assertSame(target, MaterialButtonIconTarget.of(button))
+        verify(button).getTag(any())
+    }
+
+    @Test
+    fun verifyUpdateDrawableSetsDrawable() {
+        target.updateDrawable(drawable)
+        verify(button).icon = drawable
+    }
+
+    @Test
+    fun verifyUpdateDrawableClearsDrawableWhenDrawableIsNull() {
+        target.updateDrawable(null)
+        verify(button).icon = null
+    }
+}


### PR DESCRIPTION
This will allow us to use Picasso to dynamically load an image into a `MaterialButton` icon