### PR TITLE
Enable Gradle Version Catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ buildscript {
             concurrent           : '1.1.0',
             core                 : '1.6.0',
             drawerLayout         : '1.1.1',
-            fragment             : '1.3.6',
             lifecycle            : '2.3.1',
             loader               : '1.1.0',
             localBroadcastManager: '1.0.0',

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ buildscript {
     ]
     ext.deps.androidX = [
             annotation           : '1.2.0',
-            appCompat            : '1.3.1',
             arch                 : '2.1.0',
             collection           : '1.1.0',
             concurrent           : '1.1.0',

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ buildscript {
             collection           : '1.1.0',
             concurrent           : '1.1.0',
             core                 : '1.6.0',
-            databinding          : libs.versions.android.gradle.plugin.get(),
             drawerLayout         : '1.1.1',
             fragment             : '1.3.6',
             lifecycle            : '2.3.1',

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
             dagger              : '2.38.1',
             eventbus            : '3.2.0',
             facebookFlipper     : '0.105.0',
-            gradleAndroidPlugin : '7.0.2',
             gson                : '2.8.6',
             guava               : '30.1.1-android',
             hamcrest            : '2.2',
@@ -49,7 +48,7 @@ buildscript {
             collection           : '1.1.0',
             concurrent           : '1.1.0',
             core                 : '1.6.0',
-            databinding          : deps.gradleAndroidPlugin,
+            databinding          : libs.versions.android.gradle.plugin.get(),
             drawerLayout         : '1.1.1',
             fragment             : '1.3.6',
             lifecycle            : '2.3.1',
@@ -74,7 +73,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:${deps.gradleAndroidPlugin}"
+        classpath libs.android.gradle
         classpath "com.google.dagger:hilt-android-gradle-plugin:${deps.dagger}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${deps.kotlin}"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
+android-gradle-plugin = "7.0.2"
 androidx-appcompat = "1.3.1"
 
 [libraries]
+android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+androidx-appcompat = "1.3.1"
+
+[libraries]
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,3 +5,5 @@ androidx-appcompat = "1.3.1"
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-databinding-adapters = { module = "androidx.databinding:databinding-adapters", version.ref = "android-gradle-plugin" }
+androidx-databinding-runtime = { module = "androidx.databinding:databinding-runtime", version.ref = "android-gradle-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,12 @@
 [versions]
 android-gradle-plugin = "7.0.2"
 androidx-appcompat = "1.3.1"
+androidx-fragment = "1.3.6"
 
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-databinding-adapters = { module = "androidx.databinding:databinding-adapters", version.ref = "android-gradle-plugin" }
 androidx-databinding-runtime = { module = "androidx.databinding:databinding-runtime", version.ref = "android-gradle-plugin" }
+androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidx-fragment" }
+androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }

--- a/gto-support-androidx-fragment/build.gradle
+++ b/gto-support-androidx-fragment/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    api "androidx.fragment:fragment:${deps.androidX.fragment}"
-    compileOnly "androidx.fragment:fragment-ktx:${deps.androidX.fragment}"
+    api libs.androidx.fragment
+    compileOnly libs.androidx.fragment.ktx
 }

--- a/gto-support-androidx-lifecycle/build.gradle
+++ b/gto-support-androidx-lifecycle/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation "com.github.Karumi:WeakDelegate:${deps.weakDelegate}"
 
     // Data Binding adapter dependencies
-    compileOnly "androidx.databinding:databinding-runtime:${deps.androidX.databinding}"
+    compileOnly libs.androidx.databinding.runtime
 
     testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
     testImplementation "androidx.core:core-ktx:${deps.androidX.core}"

--- a/gto-support-androidx-viewpager2/build.gradle
+++ b/gto-support-androidx-viewpager2/build.gradle
@@ -10,6 +10,6 @@ android {
 dependencies {
     api "androidx.viewpager2:viewpager2:${deps.androidX.viewPager2}"
 
-    compileOnly "androidx.databinding:databinding-adapters:${deps.androidX.databinding}"
-    compileOnly "androidx.databinding:databinding-runtime:${deps.androidX.databinding}"
+    compileOnly libs.androidx.databinding.adapters
+    compileOnly libs.androidx.databinding.runtime
 }

--- a/gto-support-appcompat/build.gradle
+++ b/gto-support-appcompat/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation project(':gto-support-core')
     implementation project(':gto-support-util')
 
-    implementation "androidx.appcompat:appcompat:${deps.androidX.appCompat}"
+    implementation libs.androidx.appcompat
 
     implementation "com.jakewharton.timber:timber:${deps.timber}"
 }

--- a/gto-support-lottie/build.gradle
+++ b/gto-support-lottie/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     api "com.airbnb.android:lottie:${deps.lottie}"
     implementation "androidx.appcompat:appcompat:${deps.androidX.appCompat}"
 
-    compileOnly "androidx.databinding:databinding-adapters:${deps.androidX.databinding}"
-    compileOnly "androidx.databinding:databinding-runtime:${deps.androidX.databinding}"
+    compileOnly libs.androidx.databinding.runtime
     compileOnly "com.squareup.okio:okio:${deps.okio}"
 }

--- a/gto-support-picasso/build.gradle
+++ b/gto-support-picasso/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
     api "com.squareup.picasso:picasso:${deps.picasso}"
 
-    compileOnly "androidx.appcompat:appcompat:${deps.androidX.appCompat}"
+    compileOnly libs.androidx.appcompat
     compileOnly "androidx.core:core-ktx:${deps.androidX.core}"
 
     compileOnly "com.google.android.material:material:${deps.materialDesign}"

--- a/gto-support-picasso/build.gradle
+++ b/gto-support-picasso/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:${deps.timber}"
 
     // databinding adapter dependencies
-    compileOnly "androidx.databinding:databinding-runtime:${deps.androidX.databinding}"
+    compileOnly libs.androidx.databinding.runtime
 
     compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
 

--- a/gto-support-realm/build.gradle
+++ b/gto-support-realm/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // RecyclerViewAdapter dependencies
     compileOnly "io.realm:android-adapters:${deps.realmAdapters}"
     compileOnly project(':gto-support-recyclerview')
-    compileOnly "androidx.databinding:databinding-runtime:${deps.androidX.databinding}"
+    compileOnly libs.androidx.databinding.runtime
     compileOnly "androidx.lifecycle:lifecycle-livedata-core:${deps.androidX.lifecycle}"
 }

--- a/gto-support-recyclerview-advrecyclerview/build.gradle
+++ b/gto-support-recyclerview-advrecyclerview/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 
     // Data Binding adapter dependencies
     compileOnly project(':gto-support-recyclerview')
-    compileOnly "androidx.databinding:databinding-runtime:${deps.androidX.databinding}"
+    compileOnly libs.androidx.databinding.runtime
 }

--- a/gto-support-recyclerview-advrecyclerview/build.gradle
+++ b/gto-support-recyclerview-advrecyclerview/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation "androidx.appcompat:appcompat:${deps.androidX.appCompat}"
+    implementation libs.androidx.appcompat
     api "androidx.recyclerview:recyclerview:${deps.androidX.recyclerView}"
 
     api "com.h6ah4i.android.widget.advrecyclerview:advrecyclerview:${deps.advrecyclerview}"

--- a/gto-support-recyclerview/build.gradle
+++ b/gto-support-recyclerview/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'com.github.Karumi:WeakDelegate:1.0.1'
 
     // Data Binding adapter dependencies
-    compileOnly "androidx.databinding:databinding-runtime:${deps.androidX.databinding}"
+    compileOnly libs.androidx.databinding.runtime
 
     // Lifecycle dependencies
     compileOnly "androidx.lifecycle:lifecycle-common:${deps.androidX.lifecycle}"

--- a/gto-support-viewpager/build.gradle
+++ b/gto-support-viewpager/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation project(':gto-support-util')
 
     api "androidx.viewpager:viewpager:${deps.androidX.viewPager}"
-    compileOnly "androidx.fragment:fragment:${deps.androidX.fragment}"
+    compileOnly libs.androidx.fragment
     compileOnly "androidx.swiperefreshlayout:swiperefreshlayout:${deps.androidX.swipeRefreshLayout}"
 
     implementation 'com.github.Karumi:WeakDelegate:1.0.1'

--- a/gto-support-viewpager/build.gradle
+++ b/gto-support-viewpager/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     implementation "com.jakewharton.timber:timber:${deps.timber}"
 
     // Data Binding adapter dependencies
-    compileOnly "androidx.databinding:databinding-runtime:${deps.androidX.databinding}"
+    compileOnly libs.androidx.databinding.runtime
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+enableFeaturePreview("VERSION_CATALOGS")
+
 include("gto-support-androidx-collection")
 include("gto-support-androidx-databinding")
 include("gto-support-androidx-drawerlayout")

--- a/testing/gto-support-dagger/build.gradle
+++ b/testing/gto-support-dagger/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     implementation "com.google.dagger:dagger:${deps.dagger}"
     api "com.google.dagger:hilt-android:${deps.dagger}"
 
-    api "androidx.appcompat:appcompat:${deps.androidX.appCompat}"
+    api libs.androidx.appcompat
 
     kapt "com.google.dagger:hilt-compiler:${deps.dagger}"
 }


### PR DESCRIPTION
- move appcompat dependency config to the version catalog
- move configuration of the gradle android plugin to the version catalog
- utilize version catalog for databinding dependencies
- move fragment dependency to version catalog
