### PR TITLE
Update several BindingAdapters

### DIFF
--- a/gto-support-androidx-databinding/src/main/java/org/ccci/gto/android/common/androidx/databinding/adapters/LifecycleObserverBindingAdapter.kt
+++ b/gto-support-androidx-databinding/src/main/java/org/ccci/gto/android/common/androidx/databinding/adapters/LifecycleObserverBindingAdapter.kt
@@ -1,0 +1,19 @@
+package org.ccci.gto.android.common.androidx.databinding.adapters
+
+import android.view.View
+import androidx.databinding.BindingAdapter
+import androidx.databinding.adapters.ListenerUtil
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import org.ccci.gto.android.common.androidx.databinding.R
+
+@BindingAdapter("lifecycleOwner")
+internal fun View.observeLifecycle(owner: LifecycleOwner?) {
+    if (this !is LifecycleObserver) return
+
+    val old = ListenerUtil.trackListener(this, owner, R.id.gto_support_databinding_lifecycleOwner)
+    if (old !== owner) {
+        old?.lifecycle?.removeObserver(this)
+        owner?.lifecycle?.addObserver(this)
+    }
+}

--- a/gto-support-androidx-databinding/src/main/res/values/ids.xml
+++ b/gto-support-androidx-databinding/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="gto_support_databinding_lifecycleOwner" type="id" />
+</resources>

--- a/gto-support-material-components/src/main/java/org/ccci/gto/android/common/material/button/databinding/MaterialButtonToggleGroupAdapters.kt
+++ b/gto-support-material-components/src/main/java/org/ccci/gto/android/common/material/button/databinding/MaterialButtonToggleGroupAdapters.kt
@@ -31,3 +31,4 @@ internal fun MaterialButtonToggleGroup.setCheckedButtonBindingListener(listener:
             ListenerUtil.trackListener(this, it, R.id.gto_support_MaterialButtonToggleGroup_checkedButtonAttr)
                 ?.let { old -> removeOnButtonCheckedListener(old) }
         }
+        ?.let { addOnButtonCheckedListener(it) }

--- a/gto-support-material-components/src/main/java/org/ccci/gto/android/common/material/button/databinding/MaterialButtonToggleGroupAdapters.kt
+++ b/gto-support-material-components/src/main/java/org/ccci/gto/android/common/material/button/databinding/MaterialButtonToggleGroupAdapters.kt
@@ -1,9 +1,22 @@
+@file:BindingMethods(
+    BindingMethod(type = MaterialButtonToggleGroup::class, method = "check", attribute = CHECKED_BUTTON_ID)
+)
+@file:InverseBindingMethods(
+    InverseBindingMethod(
+        type = MaterialButtonToggleGroup::class,
+        method = "getCheckedButtonId",
+        attribute = CHECKED_BUTTON_ID,
+        event = CHECKED_BUTTON_ATTR
+    )
+)
 package org.ccci.gto.android.common.material.button.databinding
 
-import androidx.annotation.IdRes
 import androidx.databinding.BindingAdapter
-import androidx.databinding.InverseBindingAdapter
+import androidx.databinding.BindingMethod
+import androidx.databinding.BindingMethods
 import androidx.databinding.InverseBindingListener
+import androidx.databinding.InverseBindingMethod
+import androidx.databinding.InverseBindingMethods
 import androidx.databinding.adapters.ListenerUtil
 import com.google.android.material.button.MaterialButtonToggleGroup
 import org.ccci.gto.android.common.material.components.R
@@ -11,17 +24,10 @@ import org.ccci.gto.android.common.material.components.R
 private const val CHECKED_BUTTON_ID = "checkedButtonId"
 private const val CHECKED_BUTTON_ATTR = "checkedButtonAttr"
 
-@get:IdRes
-@get:InverseBindingAdapter(attribute = CHECKED_BUTTON_ID, event = CHECKED_BUTTON_ATTR)
-@set:BindingAdapter(CHECKED_BUTTON_ID)
-internal var MaterialButtonToggleGroup.checkedButtonIdBinding: Int
-    get() = checkedButtonId
-    set(@IdRes value) = check(value)
-
 @BindingAdapter(CHECKED_BUTTON_ATTR)
 internal fun MaterialButtonToggleGroup.setCheckedButtonBindingListener(listener: InverseBindingListener?) =
     listener?.let { MaterialButtonToggleGroup.OnButtonCheckedListener { _, _, _ -> listener.onChange() } }
         .also {
-            ListenerUtil.trackListener(this, it, R.id.materialbuttontogglegroup_checkedbuttonlistener)
+            ListenerUtil.trackListener(this, it, R.id.gto_support_MaterialButtonToggleGroup_checkedButtonAttr)
                 ?.let { old -> removeOnButtonCheckedListener(old) }
         }

--- a/gto-support-material-components/src/main/java/org/ccci/gto/android/common/material/slider/databinding/SliderAdapters.kt
+++ b/gto-support-material-components/src/main/java/org/ccci/gto/android/common/material/slider/databinding/SliderAdapters.kt
@@ -1,0 +1,21 @@
+@file:InverseBindingMethods(InverseBindingMethod(type = Slider::class, attribute = "value"))
+package org.ccci.gto.android.common.material.slider.databinding
+
+import androidx.databinding.BindingAdapter
+import androidx.databinding.InverseBindingListener
+import androidx.databinding.InverseBindingMethod
+import androidx.databinding.InverseBindingMethods
+import androidx.databinding.adapters.ListenerUtil
+import com.google.android.material.slider.Slider
+import org.ccci.gto.android.common.material.components.R
+
+private const val VALUE_ATTR_CHANGED = "valueAttrChanged"
+
+@BindingAdapter(VALUE_ATTR_CHANGED)
+internal fun Slider.setValueAttrChangedListener(listener: InverseBindingListener?) =
+    listener?.let { Slider.OnChangeListener { _, _, _ -> listener.onChange() } }
+        .also {
+            ListenerUtil.trackListener(this, it, R.id.gto_support_material_components_Slider_valueAttrChangedListener)
+                ?.let { old -> removeOnChangeListener(old) }
+        }
+        ?.let { addOnChangeListener(it) }

--- a/gto-support-material-components/src/main/res/values/databinding.xml
+++ b/gto-support-material-components/src/main/res/values/databinding.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="gto_support_MaterialButtonToggleGroup_checkedButtonAttr" type="id" />
+    <item name="gto_support_material_components_Slider_valueAttrChangedListener" type="id" />
 </resources>

--- a/gto-support-material-components/src/main/res/values/databinding.xml
+++ b/gto-support-material-components/src/main/res/values/databinding.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item name="materialbuttontogglegroup_checkedbuttonlistener" type="id" />
+    <item name="gto_support_MaterialButtonToggleGroup_checkedButtonAttr" type="id" />
 </resources>


### PR DESCRIPTION
- add a binding adapter for binding a view to a LifecycleOwner
- use BindingMethod annotations to avoid needing to define methods
- actually add the onchecked listener
