### PR TITLE
cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ buildscript {
             lottie              : '4.1.0',
             mockito             : '3.12.4',
             mockitoKotlin       : '2.2.0',
-            okio                : '2.10.0',
             picasso             : '2.8',
             playCore            : '1.10.0',
             realm               : '10.8.0',
@@ -134,7 +133,7 @@ configure(subprojects.findAll { it.path.contains("gto-support") }) {
                 force "androidx.core:core:${libs.versions.androidx.core.get()}"
                 force "androidx.lifecycle:lifecycle-runtime:${deps.androidX.lifecycle}"
                 force "androidx.lifecycle:lifecycle-viewmodel-savedstate:${deps.androidX.lifecycle}"
-                force "com.squareup.okio:okio:${deps.okio}"
+                force "com.squareup.okio:okio:${libs.versions.okio.get()}"
                 force "junit:junit:${deps.junit}"
                 force "org.jetbrains.kotlinx:kotlinx-coroutines-core:${libs.versions.kotlinCoroutines.get()}"
                 force "org.jetbrains:annotations:${deps.jetbrainsAnnotations}"

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ buildscript {
             loader               : '1.1.0',
             localBroadcastManager: '1.0.0',
             recyclerView         : '1.2.1',
-            sqlite               : '2.1.0',
             swipeRefreshLayout   : '1.1.0',
             test                 : '1.4.0',
             testJUnit            : '1.1.3',

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ buildscript {
             junitParams         : '1.1.1',
             kotlin              : '1.5.30',
             kotlinCoroutines    : '1.5.2',
-            leakcanary2         : '2.7',
             lottie              : '4.1.0',
             mockito             : '3.12.4',
             mockitoKotlin       : '2.2.0',

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
             junit               : '4.13.2',
             junitParams         : '1.1.1',
             kotlin              : '1.5.30',
-            kotlinCoroutines    : '1.5.2',
             lottie              : '4.1.0',
             mockito             : '3.12.4',
             mockitoKotlin       : '2.2.0',
@@ -139,7 +138,7 @@ configure(subprojects.findAll { it.path.contains("gto-support") }) {
                 force "androidx.lifecycle:lifecycle-viewmodel-savedstate:${deps.androidX.lifecycle}"
                 force "com.squareup.okio:okio:${deps.okio}"
                 force "junit:junit:${deps.junit}"
-                force "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
+                force "org.jetbrains.kotlinx:kotlinx-coroutines-core:${libs.versions.kotlinCoroutines.get()}"
                 force "org.jetbrains:annotations:${deps.jetbrainsAnnotations}"
 
                 dependencySubstitution {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
             lottie              : '4.1.0',
             mockito             : '3.12.4',
             mockitoKotlin       : '2.2.0',
-            moshi               : '1.12.0',
             okio                : '2.10.0',
             picasso             : '2.8',
             playCore            : '1.10.0',

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ buildscript {
             playCore            : '1.10.0',
             realm               : '10.8.0',
             realmAdapters       : '4.0.0',
-            retrofit2           : '2.9.0',
             robolectric         : '4.6.1',
             scarlet             : '0.1.12',
             snowplow            : '2.2.1',

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
             mockito             : '3.12.4',
             mockitoKotlin       : '2.2.0',
             moshi               : '1.12.0',
-            okhttp3             : '4.9.1',
             okio                : '2.10.0',
             picasso             : '2.8',
             playCore            : '1.10.0',

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
             advrecyclerview     : '1.0.0',
             dagger              : '2.38.1',
             eventbus            : '3.2.0',
-            facebookFlipper     : '0.105.0',
             guava               : '30.1.1-android',
             hamcrest            : '2.2',
             jacoco              : '0.8.7',

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidx-room = "2.3.0"
 androidx-sqlite = "2.1.0"
 androidx-viewpager2 = "1.0.0"
 androidx-work = "2.6.0"
+facebookFlipper = "0.105.0"
 firebase-crashlytics = "18.2.1"
 kotlinCoroutines = "1.5.2"
 materialComponents = "1.4.0"
@@ -36,6 +37,7 @@ androidx-room-common = { module = "androidx.room:room-common", version.ref = "an
 androidx-sqlite = { module = "androidx.sqlite:sqlite", version.ref = "androidx-sqlite" }
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "androidx-viewpager2" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "androidx-work" }
+facebookFlipper = { module = "com.facebook.flipper:flipper", version.ref = "facebookFlipper" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ leakcanary = "2.7"
 moshi = "1.12.0"
 napier = "2.1.0"
 okhttp3 = "4.9.1"
+okio = "2.10.0"
 okta = "1.0.20"
 retrofit = "2.9.0"
 timber = "5.0.1"
@@ -50,6 +51,7 @@ moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", ver
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okta = { module = "com.okta.android:okta-oidc-android", version.ref = "okta" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-core = "1.6.0"
 androidx-drawerlayout = "1.1.1"
 androidx-fragment = "1.3.6"
 androidx-room = "2.3.0"
+androidx-sqlite = "2.1.0"
 androidx-viewpager2 = "1.0.0"
 androidx-work = "2.6.0"
 firebase-crashlytics = "18.2.1"
@@ -32,6 +33,7 @@ androidx-drawerlayout = { module = "androidx.drawerlayout:drawerlayout", version
 androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidx-fragment" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-room-common = { module = "androidx.room:room-common", version.ref = "androidx-room" }
+androidx-sqlite = { module = "androidx.sqlite:sqlite", version.ref = "androidx-sqlite" }
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "androidx-viewpager2" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "androidx-work" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidx-viewpager2 = "1.0.0"
 androidx-work = "2.6.0"
 firebase-crashlytics = "18.2.1"
 materialComponents = "1.4.0"
+moshi = "1.12.0"
 napier = "2.1.0"
 okhttp3 = "4.9.1"
 okta = "1.0.20"
@@ -33,6 +34,8 @@ androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
 lightweightStream = { module = "com.annimon:stream", version = "1.2.2" }
 materialComponents = { module = "com.google.android.material:material", version.ref = "materialComponents" }
+moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidx-viewpager2 = "1.0.0"
 androidx-work = "2.6.0"
 firebase-crashlytics = "18.2.1"
 materialComponents = "1.4.0"
+leakcanary = "2.7"
 moshi = "1.12.0"
 napier = "2.1.0"
 okhttp3 = "4.9.1"
@@ -33,6 +34,7 @@ androidx-room-common = { module = "androidx.room:room-common", version.ref = "an
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "androidx-viewpager2" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "androidx-work" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
+leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 lightweightStream = { module = "com.annimon:stream", version = "1.2.2" }
 materialComponents = { module = "com.google.android.material:material", version.ref = "materialComponents" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-work = "2.6.0"
 firebase-crashlytics = "18.2.1"
 materialComponents = "1.4.0"
 napier = "2.1.0"
+okhttp3 = "4.9.1"
 okta = "1.0.20"
 timber = "5.0.1"
 
@@ -33,6 +34,8 @@ firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", ve
 lightweightStream = { module = "com.annimon:stream", version = "1.2.2" }
 materialComponents = { module = "com.google.android.material:material", version.ref = "materialComponents" }
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
+okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
+okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
 okta = { module = "com.okta.android:okta-oidc-android", version.ref = "okta" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 weakdelegate = { module = "com.github.Karumi:WeakDelegate", version = "1.0.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidx-room = "2.3.0"
 androidx-viewpager2 = "1.0.0"
 androidx-work = "2.6.0"
 firebase-crashlytics = "18.2.1"
+kotlinCoroutines = "1.5.2"
 materialComponents = "1.4.0"
 leakcanary = "2.7"
 moshi = "1.12.0"
@@ -34,6 +35,9 @@ androidx-room-common = { module = "androidx.room:room-common", version.ref = "an
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "androidx-viewpager2" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "androidx-work" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
+kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
+kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
+kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
 leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 lightweightStream = { module = "com.annimon:stream", version = "1.2.2" }
 materialComponents = { module = "com.google.android.material:material", version.ref = "materialComponents" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ moshi = "1.12.0"
 napier = "2.1.0"
 okhttp3 = "4.9.1"
 okta = "1.0.20"
+retrofit = "2.9.0"
 timber = "5.0.1"
 
 [libraries]
@@ -40,5 +41,6 @@ napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
 okta = { module = "com.okta.android:okta-oidc-android", version.ref = "okta" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 weakdelegate = { module = "com.github.Karumi:WeakDelegate", version = "1.0.1" }

--- a/gto-support-androidx-lifecycle/build.gradle
+++ b/gto-support-androidx-lifecycle/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
     testImplementation libs.androidx.core.ktx
     testImplementation "androidx.lifecycle:lifecycle-runtime-testing:${deps.androidX.lifecycle}"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
+    testImplementation libs.kotlin.coroutines.test
 }

--- a/gto-support-api-okhttp3/build.gradle
+++ b/gto-support-api-okhttp3/build.gradle
@@ -1,6 +1,0 @@
-dependencies {
-    api project(':gto-support-api-base')
-    implementation project(':gto-support-okhttp3')
-
-    implementation libs.okhttp3
-}

--- a/gto-support-api-okhttp3/build.gradle
+++ b/gto-support-api-okhttp3/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     api project(':gto-support-api-base')
     implementation project(':gto-support-okhttp3')
 
-    implementation "com.squareup.okhttp3:okhttp:${deps.okhttp3}"
+    implementation libs.okhttp3
 }

--- a/gto-support-api-okhttp3/build.gradle.kts
+++ b/gto-support-api-okhttp3/build.gradle.kts
@@ -1,0 +1,6 @@
+dependencies {
+    api(project(":gto-support-api-base"))
+    implementation(project(":gto-support-okhttp3"))
+
+    implementation(libs.okhttp3)
+}

--- a/gto-support-api-retrofit2/build.gradle
+++ b/gto-support-api-retrofit2/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation project(':gto-support-compat')
 
-    api "com.squareup.retrofit2:retrofit:${deps.retrofit2}"
+    api libs.retrofit
 }

--- a/gto-support-api-retrofit2/build.gradle
+++ b/gto-support-api-retrofit2/build.gradle
@@ -1,5 +1,0 @@
-dependencies {
-    implementation project(':gto-support-compat')
-
-    api libs.retrofit
-}

--- a/gto-support-api-retrofit2/build.gradle.kts
+++ b/gto-support-api-retrofit2/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    implementation(project(":gto-support-compat"))
+
+    api(libs.retrofit)
+}

--- a/gto-support-core/build.gradle
+++ b/gto-support-core/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':gto-support-util')
 
     api "androidx.loader:loader:${deps.androidX.loader}"
-    implementation "androidx.fragment:fragment:${deps.androidX.fragment}"
+    implementation libs.androidx.fragment
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:${deps.androidX.localBroadcastManager}"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:${deps.androidX.swipeRefreshLayout}"
     compileOnly 'androidx.cursoradapter:cursoradapter:1.0.0'

--- a/gto-support-dagger/build.gradle
+++ b/gto-support-dagger/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compileOnly "com.google.dagger:hilt-android:${deps.dagger}"
 
     // OkHttp3 Module dependencies
-    compileOnly "com.squareup.okhttp3:okhttp:${deps.okhttp3}"
+    compileOnly libs.okhttp3
 
     // ViewModel Module dependencies
     compileOnly "androidx.lifecycle:lifecycle-viewmodel:${deps.androidX.lifecycle}"

--- a/gto-support-dagger/build.gradle
+++ b/gto-support-dagger/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     implementation "com.google.dagger:dagger:${deps.dagger}"
 
-    compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
+    compileOnly libs.kotlin.coroutines
 
     // Split Install dependencies
     compileOnly "com.google.android.play:core:${deps.playCore}"
@@ -23,6 +23,6 @@ dependencies {
     testImplementation "androidx.lifecycle:lifecycle-viewmodel:${deps.androidX.lifecycle}"
     testImplementation "com.google.android.play:core:${deps.playCore}"
     testImplementation "com.google.dagger:hilt-android:${deps.dagger}"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
+    testImplementation libs.kotlin.coroutines.test
     kaptTest "com.google.dagger:dagger-compiler:${deps.dagger}"
 }

--- a/gto-support-db-coroutines/build.gradle
+++ b/gto-support-db-coroutines/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':gto-support-db')
 
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
+    api libs.kotlin.coroutines
 
     // TODO: These dependencies are temporary for coroutines flow support.
     //       They should go away once we implement proper flow support

--- a/gto-support-db-livedata/build.gradle
+++ b/gto-support-db-livedata/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${deps.mockitoKotlin}"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
+    testImplementation libs.kotlin.coroutines
 }

--- a/gto-support-design/build.gradle
+++ b/gto-support-design/build.gradle
@@ -1,3 +1,0 @@
-dependencies {
-    api project(':gto-support-material-components')
-}

--- a/gto-support-design/build.gradle.kts
+++ b/gto-support-design/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    api(project(":gto-support-material-components"))
+}

--- a/gto-support-eventbus/build.gradle
+++ b/gto-support-eventbus/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 
     testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
     testImplementation "androidx.lifecycle:lifecycle-runtime-testing:${deps.androidX.lifecycle}"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
+    testImplementation libs.kotlin.coroutines.test
 }

--- a/gto-support-facebook-flipper/build.gradle
+++ b/gto-support-facebook-flipper/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnly "androidx.sqlite:sqlite:${deps.androidX.sqlite}"
+    compileOnly libs.androidx.sqlite
 
     implementation "com.facebook.flipper:flipper:${deps.facebookFlipper}"
 }

--- a/gto-support-facebook-flipper/build.gradle
+++ b/gto-support-facebook-flipper/build.gradle
@@ -1,5 +1,0 @@
-dependencies {
-    compileOnly libs.androidx.sqlite
-
-    implementation libs.facebookFlipper
-}

--- a/gto-support-facebook-flipper/build.gradle
+++ b/gto-support-facebook-flipper/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     compileOnly libs.androidx.sqlite
 
-    implementation "com.facebook.flipper:flipper:${deps.facebookFlipper}"
+    implementation libs.facebookFlipper
 }

--- a/gto-support-facebook-flipper/build.gradle.kts
+++ b/gto-support-facebook-flipper/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    implementation(libs.facebookFlipper)
+
+    compileOnly(libs.androidx.sqlite)
+}

--- a/gto-support-jsonapi-retrofit2/build.gradle
+++ b/gto-support-jsonapi-retrofit2/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':gto-support-jsonapi')
 
-    api "com.squareup.retrofit2:retrofit:${deps.retrofit2}"
+    api libs.retrofit
 
     testImplementation libs.okhttp3.mockwebserver
     testImplementation "net.javacrumbs.json-unit:json-unit:${deps.jsonUnit}"

--- a/gto-support-jsonapi-retrofit2/build.gradle
+++ b/gto-support-jsonapi-retrofit2/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 
     api "com.squareup.retrofit2:retrofit:${deps.retrofit2}"
 
-    testImplementation "com.squareup.okhttp3:mockwebserver:${deps.okhttp3}"
+    testImplementation libs.okhttp3.mockwebserver
     testImplementation "net.javacrumbs.json-unit:json-unit:${deps.jsonUnit}"
     testImplementation "net.javacrumbs.json-unit:json-unit-fluent:${deps.jsonUnit}"
     testImplementation "org.json:json:${deps.json}"

--- a/gto-support-kotlin-coroutines/build.gradle
+++ b/gto-support-kotlin-coroutines/build.gradle
@@ -1,5 +1,0 @@
-dependencies {
-    api libs.kotlin.coroutines
-
-    testImplementation libs.kotlin.coroutines.test
-}

--- a/gto-support-kotlin-coroutines/build.gradle
+++ b/gto-support-kotlin-coroutines/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
+    api libs.kotlin.coroutines
 
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
+    testImplementation libs.kotlin.coroutines.test
 }

--- a/gto-support-kotlin-coroutines/build.gradle.kts
+++ b/gto-support-kotlin-coroutines/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    api(libs.kotlin.coroutines)
+
+    testImplementation(libs.kotlin.coroutines.test)
+}

--- a/gto-support-leakcanary2/build.gradle
+++ b/gto-support-leakcanary2/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation "com.squareup.leakcanary:leakcanary-android:${deps.leakcanary2}"
+    implementation libs.leakcanary
 
     compileOnly libs.firebase.crashlytics
     compileOnly libs.timber

--- a/gto-support-leakcanary2/build.gradle
+++ b/gto-support-leakcanary2/build.gradle
@@ -1,6 +1,0 @@
-dependencies {
-    implementation libs.leakcanary
-
-    compileOnly libs.firebase.crashlytics
-    compileOnly libs.timber
-}

--- a/gto-support-leakcanary2/build.gradle.kts
+++ b/gto-support-leakcanary2/build.gradle.kts
@@ -1,0 +1,6 @@
+dependencies {
+    implementation(libs.leakcanary)
+
+    compileOnly(libs.firebase.crashlytics)
+    compileOnly(libs.timber)
+}

--- a/gto-support-lottie/build.gradle
+++ b/gto-support-lottie/build.gradle
@@ -18,5 +18,5 @@ dependencies {
     implementation libs.androidx.appcompat
 
     compileOnly libs.androidx.databinding.runtime
-    compileOnly "com.squareup.okio:okio:${deps.okio}"
+    compileOnly libs.okio
 }

--- a/gto-support-lottie/build.gradle
+++ b/gto-support-lottie/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation project(':gto-support-util')
 
     api "com.airbnb.android:lottie:${deps.lottie}"
-    implementation "androidx.appcompat:appcompat:${deps.androidX.appCompat}"
+    implementation libs.androidx.appcompat
 
     compileOnly libs.androidx.databinding.runtime
     compileOnly "com.squareup.okio:okio:${deps.okio}"

--- a/gto-support-moshi/build.gradle
+++ b/gto-support-moshi/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation project(':gto-support-compat')
 
-    api "com.squareup.moshi:moshi:${deps.moshi}"
+    api libs.moshi
 }

--- a/gto-support-moshi/build.gradle
+++ b/gto-support-moshi/build.gradle
@@ -1,5 +1,0 @@
-dependencies {
-    implementation project(':gto-support-compat')
-
-    api libs.moshi
-}

--- a/gto-support-moshi/build.gradle.kts
+++ b/gto-support-moshi/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    implementation(project(":gto-support-compat"))
+
+    api(libs.moshi)
+}

--- a/gto-support-okhttp3/build.gradle
+++ b/gto-support-okhttp3/build.gradle
@@ -1,3 +1,0 @@
-dependencies {
-    api libs.okhttp3
-}

--- a/gto-support-okhttp3/build.gradle
+++ b/gto-support-okhttp3/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    api "com.squareup.okhttp3:okhttp:${deps.okhttp3}"
+    api libs.okhttp3
 }

--- a/gto-support-okhttp3/build.gradle.kts
+++ b/gto-support-okhttp3/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    api(libs.okhttp3)
+}

--- a/gto-support-okta/build.gradle
+++ b/gto-support-okta/build.gradle
@@ -19,11 +19,11 @@ dependencies {
     // endregion LiveData
 
     // region OkHttpOktaHttpClient
-    compileOnly "com.squareup.okhttp3:okhttp:${deps.okhttp3}"
+    compileOnly libs.okhttp3
     // endregion OkHttpOktaHttpClient
 
     testImplementation project(':testing:gto-support-okta')
     testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
-    testImplementation "com.squareup.okhttp3:mockwebserver:${deps.okhttp3}"
+    testImplementation libs.okhttp3.mockwebserver
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
 }

--- a/gto-support-okta/build.gradle
+++ b/gto-support-okta/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api libs.okta
 
     // region Coroutines
-    compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
+    compileOnly libs.kotlin.coroutines
     // endregion Coroutines
 
     // region LiveData
@@ -25,5 +25,5 @@ dependencies {
     testImplementation project(':testing:gto-support-okta')
     testImplementation "androidx.arch.core:core-testing:${deps.androidX.arch}"
     testImplementation libs.okhttp3.mockwebserver
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
+    testImplementation libs.kotlin.coroutines.test
 }

--- a/gto-support-picasso/build.gradle
+++ b/gto-support-picasso/build.gradle
@@ -28,10 +28,10 @@ dependencies {
     // databinding adapter dependencies
     compileOnly libs.androidx.databinding.runtime
 
-    compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
+    compileOnly libs.kotlin.coroutines
 
     testImplementation project(':testing:gto-support-picasso')
     testImplementation libs.materialComponents
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${deps.kotlinCoroutines}"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
+    testImplementation libs.kotlin.coroutines.android
+    testImplementation libs.kotlin.coroutines.test
 }

--- a/gto-support-scarlet-actioncable/build.gradle
+++ b/gto-support-scarlet-actioncable/build.gradle
@@ -9,12 +9,12 @@ dependencies {
     }
     compileOnly "com.tinder.scarlet:websocket-okhttp:${deps.scarlet}"
 
-    implementation "com.squareup.moshi:moshi:${deps.moshi}"
+    implementation libs.moshi
 
     testImplementation "net.javacrumbs.json-unit:json-unit:${deps.jsonUnit}"
     testImplementation "net.javacrumbs.json-unit:json-unit-fluent:${deps.jsonUnit}"
     testImplementation "org.json:json:${deps.json}"
     testImplementation "pl.pragmatists:JUnitParams:${deps.junitParams}"
 
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:${deps.moshi}"
+    kapt libs.moshi.kotlin.codegen
 }

--- a/gto-support-scarlet-actioncable/build.gradle
+++ b/gto-support-scarlet-actioncable/build.gradle
@@ -9,8 +9,6 @@ dependencies {
     }
     compileOnly "com.tinder.scarlet:websocket-okhttp:${deps.scarlet}"
 
-    implementation libs.moshi
-
     testImplementation "net.javacrumbs.json-unit:json-unit:${deps.jsonUnit}"
     testImplementation "net.javacrumbs.json-unit:json-unit-fluent:${deps.jsonUnit}"
     testImplementation "org.json:json:${deps.json}"

--- a/gto-support-scarlet/build.gradle
+++ b/gto-support-scarlet/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     api "com.tinder.scarlet:scarlet-core:${deps.scarlet}"
     compileOnly "com.tinder.scarlet:scarlet:${deps.scarlet}"
 
-    implementation "com.squareup.okio:okio:${deps.okio}"
+    implementation libs.okio
 }


### PR DESCRIPTION
- track okhttp3 dependency in version catalog
- convert gto-support-okhttp3 build script to Kotlin
- convert gto-support-api-okhttp3 build script to Kotlin
- convert gto-support-dagger build script to Kotlin
- track moshi dependencies in version catalog
- convert gto-support-moshi build script to Kotlin
- move retrofit dependency to version catalog
- convert gto-support-api-retrofit2 buildscript to Kotlin
- track leakcanary dependency in version catalog
- convert gto-support-leakcanary2 build script to Kotlin
- track kotlin coroutines dependencies in version catalog
- convert gto-support-kotlin-coroutines build script to Kotlin
- update a fragment dependency to reference the version catalog
- reference appcompat dependency out of version catalog
- track androidx sqlite dependency in version catalog
- track facebook flipper dependency in version catalog
- convert gto-support-facebook-flipper to Kotlin
- track okio dependency in version catalog
- remove unnecessary moshi dependency
