### PR TITLE
Prepare for Snowplow 3.x upgrade

### DIFF
--- a/gto-support-snowplow/src/main/java/org/ccci/gto/android/common/snowplow/events/CustomEvent.kt
+++ b/gto-support-snowplow/src/main/java/org/ccci/gto/android/common/snowplow/events/CustomEvent.kt
@@ -1,0 +1,13 @@
+package org.ccci.gto.android.common.snowplow.events
+
+import com.snowplowanalytics.snowplow.event.Event
+
+sealed interface CustomEvent<E : CustomEvent<E>> : Event {
+    val attributes: MutableMap<String, String?>
+
+    fun attribute(key: String, value: String?): E {
+        attributes[key] = value
+        @Suppress("UNCHECKED_CAST")
+        return this as E
+    }
+}

--- a/gto-support-snowplow/src/main/java/org/ccci/gto/android/common/snowplow/events/CustomEventBuilder.kt
+++ b/gto-support-snowplow/src/main/java/org/ccci/gto/android/common/snowplow/events/CustomEventBuilder.kt
@@ -2,6 +2,7 @@ package org.ccci.gto.android.common.snowplow.events
 
 import com.snowplowanalytics.snowplow.event.AbstractEvent
 
-interface CustomEventBuilder<B : AbstractEvent.Builder<B>> {
+@Deprecated("Snowplow 3.x removes the Event Builder API")
+sealed interface CustomEventBuilder<B : AbstractEvent.Builder<B>> {
     fun attribute(key: String, value: String?): B
 }

--- a/gto-support-snowplow/src/main/java/org/ccci/gto/android/common/snowplow/events/CustomScreenView.kt
+++ b/gto-support-snowplow/src/main/java/org/ccci/gto/android/common/snowplow/events/CustomScreenView.kt
@@ -3,8 +3,17 @@ package org.ccci.gto.android.common.snowplow.events
 import com.snowplowanalytics.snowplow.event.ScreenView
 import com.snowplowanalytics.snowplow.internal.tracker.Tracker
 
-class CustomScreenView(builder: Builder) : ScreenView(builder) {
-    private val attributes = builder.attributes
+class CustomScreenView : ScreenView, CustomEvent<CustomScreenView> {
+    constructor(name: String) : super(name) {
+        attributes = mutableMapOf()
+    }
+
+    @Deprecated("Snowplow 3.x removes the Event Builder API")
+    private constructor(builder: Builder) : super(builder) {
+        attributes = builder.attributes.toMutableMap()
+    }
+
+    override val attributes: MutableMap<String, String?>
 
     override fun beginProcessing(tracker: Tracker) {
         EventSynchronizer.lockFor(this)
@@ -20,9 +29,11 @@ class CustomScreenView(builder: Builder) : ScreenView(builder) {
     }
 
     companion object {
+        @Deprecated("Snowplow 3.x removes the Event Builder API")
         fun builder() = Builder()
     }
 
+    @Deprecated("Snowplow 3.x removes the Event Builder API")
     class Builder : ScreenView.Builder<Builder>(), CustomEventBuilder<Builder> {
         internal val attributes = mutableMapOf<String, String?>()
 

--- a/gto-support-snowplow/src/main/java/org/ccci/gto/android/common/snowplow/events/CustomStructured.kt
+++ b/gto-support-snowplow/src/main/java/org/ccci/gto/android/common/snowplow/events/CustomStructured.kt
@@ -3,8 +3,17 @@ package org.ccci.gto.android.common.snowplow.events
 import com.snowplowanalytics.snowplow.event.Structured
 import com.snowplowanalytics.snowplow.internal.tracker.Tracker
 
-class CustomStructured(builder: Builder) : Structured(builder) {
-    private val attributes = builder.attributes
+class CustomStructured : Structured, CustomEvent<CustomStructured> {
+    constructor(category: String, action: String) : super(category, action) {
+        attributes = mutableMapOf()
+    }
+
+    @Deprecated("Snowplow 3.x removes the Event Builder API")
+    private constructor(builder: Builder) : super(builder) {
+        attributes = builder.attributes
+    }
+
+    override val attributes: MutableMap<String, String?>
 
     override fun beginProcessing(tracker: Tracker) {
         EventSynchronizer.lockFor(this)
@@ -20,9 +29,11 @@ class CustomStructured(builder: Builder) : Structured(builder) {
     }
 
     companion object {
+        @Deprecated("Snowplow 3.x removes the Event Builder API")
         fun builder() = Builder()
     }
 
+    @Deprecated("Snowplow 3.x removes the Event Builder API")
     class Builder : Structured.Builder<Builder>(), CustomEventBuilder<Builder> {
         internal val attributes = mutableMapOf<String, String?>()
 

--- a/gto-support-snowplow/src/test/java/org/ccci/gto/android/common/snowplow/events/CustomScreenViewTest.kt
+++ b/gto-support-snowplow/src/test/java/org/ccci/gto/android/common/snowplow/events/CustomScreenViewTest.kt
@@ -1,6 +1,8 @@
 package org.ccci.gto.android.common.snowplow.events
 
-class CustomScreenViewTest : CustomEventTest<CustomScreenView.Builder>() {
+class CustomScreenViewTest : CustomEventTest<CustomScreenView, CustomScreenView.Builder>() {
+    override fun event() = CustomScreenView("screen")
+
     override fun eventBuilder() = CustomScreenView.builder().name("screen")
     override fun CustomScreenView.Builder.buildEvent() = build()
 }

--- a/gto-support-snowplow/src/test/java/org/ccci/gto/android/common/snowplow/events/CustomStructuredTest.kt
+++ b/gto-support-snowplow/src/test/java/org/ccci/gto/android/common/snowplow/events/CustomStructuredTest.kt
@@ -1,6 +1,8 @@
 package org.ccci.gto.android.common.snowplow.events
 
-class CustomStructuredTest : CustomEventTest<CustomStructured.Builder>() {
+class CustomStructuredTest : CustomEventTest<CustomStructured, CustomStructured.Builder>() {
+    override fun event() = CustomStructured("category", "action")
+
     override fun eventBuilder() = CustomStructured.builder()
         .category("category")
         .action("action")


### PR DESCRIPTION
Snowplow 3.x removes the builder interface, so this is a migration step
