### PR TITLE
GT-1326 create MarginItemDecorator

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ json = { module = "org.json:json", version = "20211205" }
 jsonUnit = { module = "net.javacrumbs.json-unit:json-unit", version.ref = "jsonUnit" }
 jsonUnit-fluent = { module = "net.javacrumbs.json-unit:json-unit-fluent", version.ref = "jsonUnit" }
 junit = { module = "junit:junit", version = "4.13.2" }
-junitParams = { module = "pl.pragmatists:JUnitParams", version = "1.1.1" }
+junitParams = "pl.pragmatists:JUnitParams:1.1.1"
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }

--- a/gto-support-recyclerview/build.gradle.kts
+++ b/gto-support-recyclerview/build.gradle.kts
@@ -16,4 +16,6 @@ dependencies {
     // region *DataBindingAdapter
     compileOnly(libs.androidx.databinding.runtime)
     // endregion *DataBindingAdapter
+
+    testImplementation(libs.junitParams)
 }

--- a/gto-support-recyclerview/src/main/kotlin/org/ccci/gto/android/common/recyclerview/decorator/MarginItemDecoration.kt
+++ b/gto-support-recyclerview/src/main/kotlin/org/ccci/gto/android/common/recyclerview/decorator/MarginItemDecoration.kt
@@ -1,0 +1,35 @@
+package org.ccci.gto.android.common.recyclerview.decorator
+
+import android.graphics.Rect
+import android.view.View
+import android.view.View.LAYOUT_DIRECTION_RTL
+import androidx.annotation.Px
+import androidx.recyclerview.widget.RecyclerView
+
+class MarginItemDecoration(
+    margins: Int = 0,
+    horizontalMargins: Int = margins,
+    verticalMargins: Int = margins,
+    @Px private val leftMargin: Int = horizontalMargins,
+    @Px private val topMargin: Int = verticalMargins,
+    @Px private val rightMargin: Int = horizontalMargins,
+    @Px private val bottomMargin: Int = verticalMargins,
+    @Px private val startMargin: Int? = null,
+    @Px private val endMargin: Int? = null
+) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+        outRect.top = topMargin
+        outRect.bottom = bottomMargin
+
+        when (view.layoutDirection) {
+            LAYOUT_DIRECTION_RTL -> {
+                outRect.left = endMargin ?: leftMargin
+                outRect.right = startMargin ?: rightMargin
+            }
+            else -> {
+                outRect.left = startMargin ?: leftMargin
+                outRect.right = endMargin ?: rightMargin
+            }
+        }
+    }
+}

--- a/gto-support-recyclerview/src/test/kotlin/org/ccci/gto/android/common/recyclerview/decorator/MarginItemDecorationTest.kt
+++ b/gto-support-recyclerview/src/test/kotlin/org/ccci/gto/android/common/recyclerview/decorator/MarginItemDecorationTest.kt
@@ -1,0 +1,185 @@
+package org.ccci.gto.android.common.recyclerview.decorator
+
+import android.graphics.Rect
+import android.view.View
+import android.view.View.LAYOUT_DIRECTION_LTR
+import android.view.View.LAYOUT_DIRECTION_RTL
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import junitparams.converters.ConversionFailedException
+import junitparams.converters.Converter
+import junitparams.converters.Param
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@RunWith(JUnitParamsRunner::class)
+class MarginItemDecorationTest {
+    private val all = Random.nextInt(0, 10)
+    private val horizontal = Random.nextInt(10, 20)
+    private val vertical = Random.nextInt(20, 30)
+    private val left = Random.nextInt(30, 40)
+    private val top = Random.nextInt(40, 50)
+    private val right = Random.nextInt(50, 60)
+    private val bottom = Random.nextInt(60, 70)
+    private val start = Random.nextInt(70, 80)
+    private val end = Random.nextInt(80, 90)
+
+    @Test
+    @Parameters("ltr", "rtl")
+    fun `MarginItemDecoration()`(@Param(converter = LayoutDirectionConverter::class) dir: Int) {
+        MarginItemDecoration().testDecoration(dir) {
+            assertEquals(0, it.left)
+            assertEquals(0, it.top)
+            assertEquals(0, it.right)
+            assertEquals(0, it.bottom)
+        }
+    }
+
+    @Test
+    @Parameters("ltr", "rtl")
+    fun `MarginItemDecoration(margins = all)`(@Param(converter = LayoutDirectionConverter::class) dir: Int) {
+        MarginItemDecoration(margins = all).testDecoration(dir) {
+            assertEquals(all, it.left)
+            assertEquals(all, it.top)
+            assertEquals(all, it.right)
+            assertEquals(all, it.bottom)
+        }
+    }
+
+    @Test
+    @Parameters("ltr", "rtl")
+    fun `MarginItemDecoration(margins = all) - overrides`(@Param(converter = LayoutDirectionConverter::class) dir: Int) {
+        MarginItemDecoration(margins = all, horizontalMargins = horizontal).testDecoration(dir) {
+            assertEquals(horizontal, it.left)
+            assertEquals(all, it.top)
+            assertEquals(horizontal, it.right)
+            assertEquals(all, it.bottom)
+        }
+
+        MarginItemDecoration(margins = all, horizontalMargins = horizontal, rightMargin = right).testDecoration(dir) {
+            assertEquals(horizontal, it.left)
+            assertEquals(all, it.top)
+            assertEquals(right, it.right)
+            assertEquals(all, it.bottom)
+        }
+
+        MarginItemDecoration(margins = all, verticalMargins = vertical).testDecoration(dir) {
+            assertEquals(all, it.left)
+            assertEquals(vertical, it.top)
+            assertEquals(all, it.right)
+            assertEquals(vertical, it.bottom)
+        }
+
+        MarginItemDecoration(margins = all, verticalMargins = vertical, bottomMargin = bottom).testDecoration(dir) {
+            assertEquals(all, it.left)
+            assertEquals(vertical, it.top)
+            assertEquals(all, it.right)
+            assertEquals(bottom, it.bottom)
+        }
+    }
+
+    @Test
+    @Parameters("ltr", "rtl")
+    fun `MarginItemDecoration() - absolute`(@Param(converter = LayoutDirectionConverter::class) dir: Int) {
+        MarginItemDecoration(
+            leftMargin = left,
+            topMargin = top,
+            rightMargin = right,
+            bottomMargin = bottom
+        ).testDecoration(dir) {
+            assertEquals(left, it.left)
+            assertEquals(top, it.top)
+            assertEquals(right, it.right)
+            assertEquals(bottom, it.bottom)
+        }
+    }
+
+    @Test
+    @Parameters("ltr", "rtl")
+    fun `MarginItemDecoration() - relative`(@Param(converter = LayoutDirectionConverter::class) dir: Int) {
+        MarginItemDecoration(
+            leftMargin = left,
+            rightMargin = right,
+            startMargin = start,
+            endMargin = end
+        ).testDecoration(dir) {
+            assertNotEquals(left, it.left)
+            assertNotEquals(right, it.right)
+            when (dir) {
+                LAYOUT_DIRECTION_LTR -> {
+                    assertEquals(start, it.left)
+                    assertEquals(end, it.right)
+                }
+                LAYOUT_DIRECTION_RTL -> {
+                    assertEquals(end, it.left)
+                    assertEquals(start, it.right)
+                }
+                else -> fail()
+            }
+        }
+    }
+
+    @Test
+    fun `MarginItemDecoration() - relative - startMargin fallbacks`() {
+        val decoration = MarginItemDecoration(
+            leftMargin = left,
+            rightMargin = right,
+            startMargin = start
+        )
+
+        decoration.testDecoration(LAYOUT_DIRECTION_LTR) {
+            assertEquals(start, it.left)
+            assertNotEquals(left, it.left)
+            assertEquals(right, it.right)
+        }
+
+        decoration.testDecoration(LAYOUT_DIRECTION_RTL) {
+            assertEquals(left, it.left)
+            assertEquals(start, it.right)
+            assertNotEquals(right, it.right)
+        }
+    }
+
+    @Test
+    fun `MarginItemDecoration() - relative - endMargin fallbacks`() {
+        val decoration = MarginItemDecoration(
+            leftMargin = left,
+            rightMargin = right,
+            endMargin = end
+        )
+
+        decoration.testDecoration(LAYOUT_DIRECTION_LTR) {
+            assertEquals(left, it.left)
+            assertEquals(end, it.right)
+            assertNotEquals(right, it.right)
+        }
+
+        decoration.testDecoration(LAYOUT_DIRECTION_RTL) {
+            assertEquals(end, it.left)
+            assertNotEquals(left, it.left)
+            assertEquals(right, it.right)
+        }
+    }
+
+    private fun MarginItemDecoration.testDecoration(dir: Int, block: (Rect) -> Unit) {
+        val outRect = Rect()
+        val view = mock<View> { on { layoutDirection } doReturn dir }
+        getItemOffsets(outRect, view, mock(), mock())
+        block(outRect)
+    }
+
+    class LayoutDirectionConverter : Converter<Param, Int> {
+        override fun initialize(annotation: Param?) = Unit
+        override fun convert(param: Any) = when (param) {
+            "ltr" -> LAYOUT_DIRECTION_LTR
+            "rtl" -> LAYOUT_DIRECTION_RTL
+            else -> throw ConversionFailedException("Invalid layout direction: $param")
+        }
+    }
+}


### PR DESCRIPTION
The `MarginItemDecorator` supports adding margin to RecyclerView Items. This will be used by GT-1326 to provide horizontal space to show adjacent cards