### PR TITLE
create a FragmentManager.hasPendingActions extension property

### DIFF
--- a/gto-support-androidx-fragment/build.gradle.kts
+++ b/gto-support-androidx-fragment/build.gradle.kts
@@ -5,8 +5,13 @@ plugins {
 
 configureAndroidLibrary()
 
+android {
+    defaultConfig.consumerProguardFiles("proguard-consumer.pro")
+}
+
 dependencies {
     api(libs.androidx.fragment)
+    implementation(project(":gto-support-util"))
     compileOnly(libs.androidx.fragment.ktx)
 
     // DataBindingDialogFragment dependencies

--- a/gto-support-androidx-fragment/proguard-consumer.pro
+++ b/gto-support-androidx-fragment/proguard-consumer.pro
@@ -1,0 +1,4 @@
+-keepclassmembernames class androidx.fragment.app.FragmentManager {
+    # keep for androidx.fragment.app.FragmentManagerInternalsKt#pendingActionsField
+    java.util.ArrayList mPendingActions;
+}

--- a/gto-support-androidx-fragment/src/main/kotlin/androidx/fragment/app/FragmentManagerInternals.kt
+++ b/gto-support-androidx-fragment/src/main/kotlin/androidx/fragment/app/FragmentManagerInternals.kt
@@ -1,0 +1,8 @@
+package androidx.fragment.app
+
+import org.ccci.gto.android.common.util.getDeclaredFieldOrNull
+
+private val pendingActionsField by lazy { getDeclaredFieldOrNull<FragmentManager>("mPendingActions") }
+
+internal val FragmentManager.pendingActions
+    get() = pendingActionsField?.get(this) as? ArrayList<FragmentManager.OpGenerator>

--- a/gto-support-androidx-fragment/src/main/kotlin/org/ccci/gto/android/common/androidx/fragment/app/FragmentManager.kt
+++ b/gto-support-androidx-fragment/src/main/kotlin/org/ccci/gto/android/common/androidx/fragment/app/FragmentManager.kt
@@ -1,6 +1,7 @@
 package org.ccci.gto.android.common.androidx.fragment.app
 
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.pendingActions
 
 internal fun FragmentManager.backStackEntriesIterator() = object : ListIterator<FragmentManager.BackStackEntry> {
     private val manager = this@backStackEntriesIterator
@@ -18,3 +19,5 @@ val FragmentManager.backStackEntries
     get() = object : Sequence<FragmentManager.BackStackEntry> {
         override fun iterator() = backStackEntriesIterator()
     }
+
+val FragmentManager.hasPendingActions get() = pendingActions!!.isNotEmpty()


### PR DESCRIPTION
this will allow us to more intelligently trigger `executePendingTransactions()`
