### PR TITLE
Don't depend on LiveData for gto-support-db-coroutines

### DIFF
--- a/gto-support-db-coroutines/build.gradle.kts
+++ b/gto-support-db-coroutines/build.gradle.kts
@@ -10,8 +10,5 @@ dependencies {
 
     api(libs.kotlin.coroutines)
 
-    // TODO: These dependencies are temporary for coroutines flow support.
-    //       They should go away once we implement proper flow support
-    api(project(":gto-support-db-livedata"))
-    api(libs.androidx.lifecycle.livedata.ktx)
+    testImplementation(libs.kotlin.coroutines.test)
 }

--- a/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDao.kt
+++ b/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDao.kt
@@ -1,17 +1,36 @@
 package org.ccci.gto.android.common.db
 
 import androidx.annotation.AnyThread
-import androidx.lifecycle.asFlow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
-interface CoroutinesFlowDao : CoroutinesDao, LiveDataDao {
-    @AnyThread
-    fun <T : Any> findAsFlow(clazz: Class<T>, vararg key: Any) = findLiveData(clazz, *key).asFlow()
+interface CoroutinesFlowDao : CoroutinesDao, Dao {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun invalidationFlow(types: Collection<Class<*>>) = when {
+        types.isEmpty() -> flowOf(Unit)
+        else -> callbackFlow {
+            val callback = Dao.InvalidationCallback { if (it in types) trySendBlocking(it) }
+            registerInvalidationCallback(callback)
+            send(types.first())
+            awaitClose { unregisterInvalidationCallback(callback) }
+        }
+    }
 
     @AnyThread
-    fun <T : Any> getAsFlow(query: Query<T>) = getLiveData(query).asFlow()
+    fun <T : Any> findAsFlow(clazz: Class<T>, vararg key: Any) =
+        invalidationFlow(listOf(clazz)).map { find(clazz, *key) }
 
     @AnyThread
-    fun <T : Any> getCursorAsFlow(query: Query<T>) = getCursorLiveData(query).asFlow()
+    fun <T : Any> getAsFlow(query: Query<T>) =
+        invalidationFlow(query.allTables.map { it.type }.toSet()).map { get(query) }
+
+    @AnyThread
+    fun <T : Any> getCursorAsFlow(query: Query<T>) =
+        invalidationFlow(query.allTables.map { it.type }.toSet()).map { getCursor(query) }
 }
 
 inline fun <reified T : Any> CoroutinesFlowDao.findAsFlow(vararg key: Any) = findAsFlow(T::class.java, *key)

--- a/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDao.kt
+++ b/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDao.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -19,7 +20,7 @@ interface CoroutinesFlowDao : CoroutinesDao, Dao {
             registerInvalidationCallback(callback)
             send(types.first())
             awaitClose { unregisterInvalidationCallback(callback) }
-        }
+        }.conflate()
     }
 
     @AnyThread

--- a/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDao.kt
+++ b/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDao.kt
@@ -1,11 +1,13 @@
 package org.ccci.gto.android.common.db
 
 import androidx.annotation.AnyThread
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 
 interface CoroutinesFlowDao : CoroutinesDao, Dao {
@@ -22,15 +24,15 @@ interface CoroutinesFlowDao : CoroutinesDao, Dao {
 
     @AnyThread
     fun <T : Any> findAsFlow(clazz: Class<T>, vararg key: Any) =
-        invalidationFlow(listOf(clazz)).map { find(clazz, *key) }
+        invalidationFlow(listOf(clazz)).map { find(clazz, *key) }.flowOn(Dispatchers.IO)
 
     @AnyThread
     fun <T : Any> getAsFlow(query: Query<T>) =
-        invalidationFlow(query.allTables.map { it.type }.toSet()).map { get(query) }
+        invalidationFlow(query.allTables.map { it.type }.toSet()).map { get(query) }.flowOn(Dispatchers.IO)
 
     @AnyThread
     fun <T : Any> getCursorAsFlow(query: Query<T>) =
-        invalidationFlow(query.allTables.map { it.type }.toSet()).map { getCursor(query) }
+        invalidationFlow(query.allTables.map { it.type }.toSet()).map { getCursor(query) }.flowOn(Dispatchers.IO)
 }
 
 inline fun <reified T : Any> CoroutinesFlowDao.findAsFlow(vararg key: Any) = findAsFlow(T::class.java, *key)

--- a/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDao.kt
+++ b/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDao.kt
@@ -18,7 +18,7 @@ interface CoroutinesFlowDao : CoroutinesDao, Dao {
         else -> callbackFlow {
             val callback = Dao.InvalidationCallback { if (it in types) trySendBlocking(it) }
             registerInvalidationCallback(callback)
-            send(types.first())
+            send(Unit)
             awaitClose { unregisterInvalidationCallback(callback) }
         }.conflate()
     }

--- a/gto-support-db-coroutines/src/test/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDaoTest.kt
+++ b/gto-support-db-coroutines/src/test/kotlin/org/ccci/gto/android/common/db/CoroutinesFlowDaoTest.kt
@@ -1,0 +1,56 @@
+package org.ccci.gto.android.common.db
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoroutinesFlowDaoTest {
+    private val dao = spy<CoroutinesFlowDao>()
+
+    @Test
+    fun verifyFindAsFlowMonitorsInvalidations() = runBlockingTest {
+        val job = dao.findAsFlow(String::class.java).launchIn(this)
+        val callback = verifyInvalidationCallback()
+        verify(dao, never()).unregisterInvalidationCallback(any())
+
+        job.cancel()
+        verify(dao).unregisterInvalidationCallback(callback)
+    }
+
+    @Test
+    fun verifyFindAsFlow() = runBlockingTest {
+        pauseDispatcher()
+        val flow = dao.findAsFlow(String::class.java).launchIn(this)
+        verify(dao, never()).find(String::class.java)
+
+        // initial trigger
+        advanceUntilIdle()
+        val callback = verifyInvalidationCallback()
+        verify(dao).find(String::class.java)
+        clearInvocations(dao)
+
+        // invalidation triggers processing
+        callback.onInvalidate(String::class.java)
+        advanceUntilIdle()
+        verify(dao).find(String::class.java)
+        clearInvocations(dao)
+
+        // invalidation of a class not being monitored isn't collected
+        callback.onInvalidate(Float::class.java)
+        advanceUntilIdle()
+        verify(dao, never()).find(String::class.java)
+
+        flow.cancel()
+    }
+
+    private fun verifyInvalidationCallback() =
+        argumentCaptor<Dao.InvalidationCallback> { verify(dao).registerInvalidationCallback(capture()) }.firstValue
+}

--- a/gto-support-db-livedata/src/main/kotlin/org/ccci/gto/android/common/db/LiveDataDao.kt
+++ b/gto-support-db-livedata/src/main/kotlin/org/ccci/gto/android/common/db/LiveDataDao.kt
@@ -70,17 +70,7 @@ class LiveDataRegistry {
 
     @MainThread
     internal fun DaoComputableLiveData<*>.registerFor(query: Query<*>) {
-        registerFor(query.table)
-        query.joins.forEach { registerFor(it) }
-    }
-
-    @MainThread
-    private fun DaoComputableLiveData<*>.registerFor(table: Table<*>) = registerFor(table.type)
-
-    @MainThread
-    private fun DaoComputableLiveData<*>.registerFor(join: Join<*, *>) {
-        join.base?.let { registerFor(it) }
-        registerFor(join.target)
+        query.allTables.forEach { registerFor(it.type) }
     }
 
     @AnyThread

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Dao.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Dao.kt
@@ -82,6 +82,16 @@ interface Dao {
     fun delete(clazz: Class<*>, where: Expression?)
     // endregion Read-Write
     // endregion Queries
+
+    // region Data Invalidation
+    fun interface InvalidationCallback {
+        @WorkerThread
+        fun onInvalidate(clazz: Class<*>)
+    }
+
+    fun registerInvalidationCallback(callback: InvalidationCallback)
+    fun unregisterInvalidationCallback(callback: InvalidationCallback)
+    // endregion Data Invalidation
 }
 
 inline fun <reified T : Any> Dao.find(vararg key: Any) = find(T::class.java, *key)

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Join.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Join.kt
@@ -22,6 +22,8 @@ data class Join<S : Any, T : Any> private constructor(
         fun <S : Any, T : Any> create(target: Table<T>) = Join<S, T>(target = target)
     }
 
+    internal val allTables: Sequence<Table<*>> get() = sequenceOf(target) + base?.allTables.orEmpty()
+
     fun type(type: String?) = copy(type = type)
     fun on(on: Expression?) = copy(on = on)
     fun andOn(on: Expression) = copy(on = this.on?.and(on) ?: on)

--- a/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Query.kt
+++ b/gto-support-db/src/main/java/org/ccci/gto/android/common/db/Query.kt
@@ -29,6 +29,9 @@ data class Query<T : Any> private constructor(
         inline fun <reified T : Any> select() = select(T::class.java)
     }
 
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    val allTables get() = sequenceOf(table) + joins.flatMap { it.allTables }
+
     fun distinct(isDistinct: Boolean) = copy(isDistinct = isDistinct)
     fun join(vararg joins: Join<T, *>) = copy(joins = this.joins + joins)
     fun joins(vararg joins: Join<T, *>) = copy(joins = joins.toList())

--- a/gto-support-db/src/test/java/org/ccci/gto/android/common/db/AbstractDaoClassInvalidationTest.kt
+++ b/gto-support-db/src/test/java/org/ccci/gto/android/common/db/AbstractDaoClassInvalidationTest.kt
@@ -24,7 +24,7 @@ class AbstractDaoClassInvalidationTest : BaseAbstractDaoTest() {
     @Test
     fun verifyInvalidateClassWithoutTransaction() {
         dao.invalidate(Model1::class.java)
-        assertThat(dao.invalidatedClasses, contains<Class<*>>(Model1::class.java))
+        assertThat(dao.invalidatedClasses, contains(Model1::class.java))
     }
 
     @Test
@@ -33,7 +33,7 @@ class AbstractDaoClassInvalidationTest : BaseAbstractDaoTest() {
             dao.invalidate(Model1::class.java)
             assertThat(dao.invalidatedClasses, empty())
         }
-        assertThat(dao.invalidatedClasses, contains<Class<*>>(Model1::class.java))
+        assertThat(dao.invalidatedClasses, contains(Model1::class.java))
     }
 
     @Test

--- a/gto-support-db/src/test/java/org/ccci/gto/android/common/db/BaseAbstractDaoTest.kt
+++ b/gto-support-db/src/test/java/org/ccci/gto/android/common/db/BaseAbstractDaoTest.kt
@@ -40,13 +40,11 @@ abstract class BaseAbstractDaoTest {
     protected fun Stubber.wheneverGetPrimaryKeyWhere(obj: Any) = whenever(dao).getPrimaryKeyWhere(obj)
 
     protected class TestDao(helper: SQLiteOpenHelper) : AbstractDao(helper) {
+        val invalidatedClasses = mutableListOf<Class<*>>()
+
         init {
             registerType(Model1::class.java, Model1.TABLE_NAME, arrayOf(Model1.FIELD_NAME), null, null)
-        }
-
-        val invalidatedClasses = mutableListOf<Class<*>>()
-        override fun onInvalidateClass(clazz: Class<*>) {
-            invalidatedClasses += clazz
+            registerInvalidationCallback { invalidatedClasses += it }
         }
 
         fun invalidate(clazz: Class<*>) = invalidateClass(clazz)


### PR DESCRIPTION
- create an internal allTables property on query objects
- support registering arbitrary invalidation callbacks
- use a callbackFlow that monitors invalidations to retrigger evaluation of db query
