### PR TITLE
GT-1402 Workaround a corrupted TokenResponse

### DIFF
--- a/gto-support-okta/src/main/kotlin/com/okta/oidc/net/response/TokenResponseInternals.kt
+++ b/gto-support-okta/src/main/kotlin/com/okta/oidc/net/response/TokenResponseInternals.kt
@@ -1,0 +1,12 @@
+package com.okta.oidc.net.response
+
+import org.ccci.gto.android.common.util.getDeclaredFieldOrNull
+import org.ccci.gto.android.common.util.getOrNull
+
+private val expiresInField by lazy { getDeclaredFieldOrNull<TokenResponse>("expires_in") }
+
+internal var TokenResponse.expires_in: String?
+    get() = expiresInField?.getOrNull<String>(this)
+    set(value) {
+        expiresInField?.set(this, value)
+    }

--- a/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/OktaUserProfileProvider.kt
+++ b/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/OktaUserProfileProvider.kt
@@ -29,6 +29,7 @@ import org.ccci.gto.android.common.okta.oidc.clients.sessions.oktaRepo
 import org.ccci.gto.android.common.okta.oidc.clients.sessions.oktaUserId
 import org.ccci.gto.android.common.okta.oidc.clients.sessions.oktaUserIdFlow
 import org.ccci.gto.android.common.okta.oidc.clients.sessions.refreshToken
+import org.ccci.gto.android.common.okta.oidc.clients.sessions.tokensSafe
 import org.ccci.gto.android.common.okta.oidc.net.response.PersistableUserInfo
 import org.ccci.gto.android.common.okta.oidc.net.response.oktaUserId
 import org.ccci.gto.android.common.okta.oidc.storage.getPersistableUserInfo
@@ -101,7 +102,7 @@ class OktaUserProfileProvider @VisibleForTesting internal constructor(
     private suspend fun loadUserProfile() {
         if (!sessionClient.isAuthenticated) return
         try {
-            if (sessionClient.tokens?.isAccessTokenExpired != false) sessionClient.refreshToken()
+            if (sessionClient.tokensSafe?.isAccessTokenExpired != false) sessionClient.refreshToken()
             val profile = sessionClient.getUserProfile()
             profile.oktaUserId?.let { oktaRepo.save(PersistableUserInfo(it, profile)) }
         } catch (e: AuthorizationException) {

--- a/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/clients/sessions/SessionClient.kt
+++ b/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/clients/sessions/SessionClient.kt
@@ -1,15 +1,26 @@
 package org.ccci.gto.android.common.okta.oidc.clients.sessions
 
+import android.annotation.SuppressLint
+import com.okta.oidc.Tokens
 import com.okta.oidc.clients.sessions.SessionClient
 import com.okta.oidc.clients.sessions.oktaState
 import com.okta.oidc.clients.sessions.syncSessionClient
 import com.okta.oidc.oktaRepo
 import com.okta.oidc.storage.storage
+import org.ccci.gto.android.common.okta.oidc.net.response.repair
 import org.ccci.gto.android.common.okta.oidc.oktaUserId
 import org.ccci.gto.android.common.okta.oidc.parseIdToken
 
 internal val SessionClient.oktaRepo get() = syncSessionClient!!.oktaState!!.oktaRepo!!
 internal val SessionClient.oktaStorage get() = oktaRepo.storage!!
 
-val SessionClient.idToken get() = tokens?.idToken?.parseIdToken()
-val SessionClient.oktaUserId get() = tokens?.oktaUserId
+@get:SuppressLint("RestrictedApi")
+internal val SessionClient.tokensSafe
+    get() = try {
+        tokens
+    } catch (e: NumberFormatException) {
+        syncSessionClient!!.oktaState!!.tokenResponse?.repair()?.let { Tokens(it) }
+    }
+
+val SessionClient.idToken get() = tokensSafe?.idToken?.parseIdToken()
+val SessionClient.oktaUserId get() = tokensSafe?.oktaUserId

--- a/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/clients/sessions/SessionClientCoroutines.kt
+++ b/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/clients/sessions/SessionClientCoroutines.kt
@@ -42,7 +42,7 @@ suspend fun SessionClient.refreshToken(): Tokens = suspendCoroutine { cont ->
 
 internal fun SessionClient.changeFlow() = (oktaStorage as ChangeAwareOktaStorage).changeFlow()
 
-private fun SessionClient.tokensFlow(): Flow<Tokens?> = changeFlow().map { tokens }.conflate()
+private fun SessionClient.tokensFlow(): Flow<Tokens?> = changeFlow().map { tokensSafe }.conflate()
 fun SessionClient.idTokenFlow() =
     tokensFlow().map { it?.idToken }.distinctUntilChanged().map { it?.let { OktaIdToken.parseIdToken(it) } }.conflate()
 fun SessionClient.oktaUserIdFlow() = idTokenFlow().map { it?.claims?.sub }.distinctUntilChanged().conflate()

--- a/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/clients/sessions/SessionClientLiveData.kt
+++ b/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/clients/sessions/SessionClientLiveData.kt
@@ -10,6 +10,6 @@ import org.ccci.gto.android.common.okta.oidc.storage.changeLiveData
 private inline val SessionClient.changeLiveData get() = (oktaStorage as ChangeAwareOktaStorage).changeLiveData
 
 val SessionClient.isAuthenticatedLiveData get() = changeLiveData.map { isAuthenticated }.distinctUntilChanged()
-private val SessionClient.tokensLiveData get() = changeLiveData.map { tokens }
+private val SessionClient.tokensLiveData get() = changeLiveData.map { tokensSafe }
 val SessionClient.idTokenLiveData
     get() = tokensLiveData.map { it?.idToken }.distinctUntilChanged().map { it?.let { OktaIdToken.parseIdToken(it) } }

--- a/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/net/response/TokenResponse.kt
+++ b/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/net/response/TokenResponse.kt
@@ -1,0 +1,15 @@
+@file:SuppressLint("RestrictedApi")
+package org.ccci.gto.android.common.okta.oidc.net.response
+
+import android.annotation.SuppressLint
+import com.okta.oidc.net.response.TokenResponse
+import com.okta.oidc.net.response.expires_in
+import java.lang.NumberFormatException
+
+internal fun TokenResponse.repair() = apply {
+    try {
+        Integer.parseInt(expiresIn)
+    } catch (e: NumberFormatException) {
+        expires_in = "0"
+    }
+}

--- a/gto-support-okta/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/net/response/TokenResponseTest.kt
+++ b/gto-support-okta/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/net/response/TokenResponseTest.kt
@@ -1,0 +1,21 @@
+package org.ccci.gto.android.common.okta.oidc.net.response
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.gson.Gson
+import com.okta.oidc.Tokens
+import com.okta.oidc.net.response.TokenResponse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TokenResponseTest {
+    @Test
+    fun verifyRepair() {
+        val tokenResponse = Gson().fromJson("{}", TokenResponse::class.java)
+
+        assertThrows(NumberFormatException::class.java) { Tokens(tokenResponse) }
+        assertNotNull(Tokens(tokenResponse.repair()))
+    }
+}


### PR DESCRIPTION
- add an internal method that will "repair" a corrupted TokenResponse
- provide a tokensSafe internal property that attempts to work around a corrupted TokenResponse
