### PR TITLE
cleanup

### DIFF
--- a/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesAsyncDao.kt
+++ b/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesAsyncDao.kt
@@ -4,21 +4,21 @@ import android.database.sqlite.SQLiteDatabase
 import kotlinx.coroutines.async
 
 interface CoroutinesAsyncDao : CoroutinesDao {
-    fun <T : Any> findAsync(clazz: Class<T>, vararg key: Any) = coroutinesScope.async { find(clazz, *key) }
-    fun <T : Any> getAsync(query: Query<T>) = coroutinesScope.async { get(query) }
-    fun getCursorAsync(query: Query<*>) = coroutinesScope.async { getCursor(query) }
+    fun <T : Any> findAsync(clazz: Class<T>, vararg key: Any) = coroutineScope.async { find(clazz, *key) }
+    fun <T : Any> getAsync(query: Query<T>) = coroutineScope.async { get(query) }
+    fun getCursorAsync(query: Query<*>) = coroutineScope.async { getCursor(query) }
 
     fun insertAsync(obj: Any, conflictAlgorithm: Int = SQLiteDatabase.CONFLICT_NONE) =
-        coroutinesScope.async { insert(obj, conflictAlgorithm) }
+        coroutineScope.async { insert(obj, conflictAlgorithm) }
 
     fun updateAsync(obj: Any) = updateAsync(obj, *getFullProjection(obj.javaClass))
-    fun updateAsync(obj: Any, vararg projection: String) = coroutinesScope.async { update(obj, *projection) }
+    fun updateAsync(obj: Any, vararg projection: String) = coroutineScope.async { update(obj, *projection) }
     fun <T : Any> updateAsync(sample: T, where: Expression?, vararg projection: String) =
-        coroutinesScope.async { update(sample, where, *projection) }
+        coroutineScope.async { update(sample, where, *projection) }
 
     fun updateOrInsertAsync(obj: Any) = updateOrInsertAsync(obj, *getFullProjection(obj.javaClass))
     fun updateOrInsertAsync(obj: Any, vararg projection: String) =
-        coroutinesScope.async { updateOrInsert(obj, *projection) }
+        coroutineScope.async { updateOrInsert(obj, *projection) }
 }
 
 inline fun <reified T : Any> CoroutinesAsyncDao.findAsync(vararg key: Any) = findAsync(T::class.java, *key)

--- a/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesDao.kt
+++ b/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesDao.kt
@@ -1,5 +1,6 @@
 package org.ccci.gto.android.common.db
 
+import androidx.annotation.RestrictTo
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -10,8 +11,10 @@ private const val COROUTINES_PARALLELISM = 4
 
 interface CoroutinesDao : Dao {
     @OptIn(ExperimentalCoroutinesApi::class)
+    @get:RestrictTo(RestrictTo.Scope.SUBCLASSES)
     val coroutineDispatcher: CoroutineDispatcher
         get() = getService { Dispatchers.IO.limitedParallelism(COROUTINES_PARALLELISM) }
+    @get:RestrictTo(RestrictTo.Scope.SUBCLASSES)
     val coroutineScope: CoroutineScope
         get() = getService { CoroutineScope(coroutineDispatcher + SupervisorJob()) }
 }

--- a/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesDao.kt
+++ b/gto-support-db-coroutines/src/main/kotlin/org/ccci/gto/android/common/db/CoroutinesDao.kt
@@ -12,6 +12,6 @@ interface CoroutinesDao : Dao {
     @OptIn(ExperimentalCoroutinesApi::class)
     val coroutineDispatcher: CoroutineDispatcher
         get() = getService { Dispatchers.IO.limitedParallelism(COROUTINES_PARALLELISM) }
-    val coroutinesScope: CoroutineScope
+    val coroutineScope: CoroutineScope
         get() = getService { CoroutineScope(coroutineDispatcher + SupervisorJob()) }
 }

--- a/gto-support-db-livedata/src/main/kotlin/org/ccci/gto/android/common/db/LiveDataDao.kt
+++ b/gto-support-db-livedata/src/main/kotlin/org/ccci/gto/android/common/db/LiveDataDao.kt
@@ -12,7 +12,7 @@ import java.util.WeakHashMap
 
 interface LiveDataDao : Dao {
     @get:RestrictTo(RestrictTo.Scope.SUBCLASSES)
-    val liveDataRegistry: LiveDataRegistry
+    val liveDataRegistry get() = getService { LiveDataRegistry() }
 
     @MainThread
     @SuppressLint("RestrictedApi")

--- a/gto-support-db-livedata/src/main/kotlin/org/ccci/gto/android/common/db/LiveDataDao.kt
+++ b/gto-support-db-livedata/src/main/kotlin/org/ccci/gto/android/common/db/LiveDataDao.kt
@@ -2,17 +2,14 @@ package org.ccci.gto.android.common.db
 
 import android.annotation.SuppressLint
 import android.database.Cursor
-import androidx.annotation.AnyThread
 import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
-import androidx.collection.SimpleArrayMap
 import androidx.lifecycle.ComputableLiveData
 import androidx.lifecycle.LiveData
-import java.util.WeakHashMap
 
 interface LiveDataDao : Dao {
     @get:RestrictTo(RestrictTo.Scope.SUBCLASSES)
-    val liveDataRegistry get() = getService { LiveDataRegistry() }
+    val liveDataRegistry get() = getService { LiveDataRegistry(this) }
 
     @MainThread
     @SuppressLint("RestrictedApi")
@@ -55,31 +52,6 @@ private class DaoGetCursorComputableLiveData<T : Any>(dao: LiveDataDao, private 
     override fun compute() = dao.getCursor(query)
 }
 // endregion DaoComputableLiveData
-
-class LiveDataRegistry {
-    private val registry: SimpleArrayMap<Class<*>, MutableMap<ComputableLiveData<*>, Unit>> = SimpleArrayMap()
-
-    @MainThread
-    internal fun DaoComputableLiveData<*>.registerFor(clazz: Class<*>) {
-        synchronized(registry) {
-            (registry[clazz] ?: WeakHashMap<ComputableLiveData<*>, Unit>().also { registry.put(clazz, it) })[this] =
-                Unit
-        }
-    }
-
-    @MainThread
-    internal fun DaoComputableLiveData<*>.registerFor(query: Query<*>) {
-        query.allTables.forEach { registerFor(it.type) }
-    }
-
-    @AnyThread
-    @SuppressLint("RestrictedApi")
-    fun invalidate(clazz: Class<*>) {
-        synchronized(registry) {
-            registry[clazz]?.keys?.forEach { it.invalidate() }
-        }
-    }
-}
 
 inline fun <reified T : Any> LiveDataDao.findLiveData(vararg key: Any) = findLiveData(T::class.java, *key)
 fun <T : Any> Query<T>.getAsLiveData(dao: LiveDataDao) = dao.getLiveData(this)

--- a/gto-support-db-livedata/src/main/kotlin/org/ccci/gto/android/common/db/LiveDataRegistry.kt
+++ b/gto-support-db-livedata/src/main/kotlin/org/ccci/gto/android/common/db/LiveDataRegistry.kt
@@ -1,0 +1,38 @@
+package org.ccci.gto.android.common.db
+
+import android.annotation.SuppressLint
+import androidx.annotation.AnyThread
+import androidx.annotation.MainThread
+import androidx.annotation.WorkerThread
+import androidx.collection.SimpleArrayMap
+import androidx.lifecycle.ComputableLiveData
+import java.util.WeakHashMap
+
+class LiveDataRegistry(dao: Dao) {
+    private val registry: SimpleArrayMap<Class<*>, MutableMap<ComputableLiveData<*>, Unit>> = SimpleArrayMap()
+
+    init {
+        dao.registerInvalidationCallback(this::invalidate)
+    }
+
+    @MainThread
+    internal fun DaoComputableLiveData<*>.registerFor(clazz: Class<*>) {
+        synchronized(registry) {
+            (registry[clazz] ?: WeakHashMap<ComputableLiveData<*>, Unit>().also { registry.put(clazz, it) })[this] =
+                Unit
+        }
+    }
+
+    @MainThread
+    internal fun DaoComputableLiveData<*>.registerFor(query: Query<*>) {
+        query.allTables.forEach { registerFor(it.type) }
+    }
+
+    @WorkerThread
+    @SuppressLint("RestrictedApi")
+    internal fun invalidate(clazz: Class<*>) {
+        synchronized(registry) {
+            registry[clazz]?.keys?.forEach { it.invalidate() }
+        }
+    }
+}

--- a/gto-support-db-livedata/src/test/java/org/ccci/gto/android/common/db/JavaLiveDataDao.java
+++ b/gto-support-db-livedata/src/test/java/org/ccci/gto/android/common/db/JavaLiveDataDao.java
@@ -3,21 +3,11 @@ package org.ccci.gto.android.common.db;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
-import org.jetbrains.annotations.NotNull;
-
 import androidx.annotation.NonNull;
 
 public final class JavaLiveDataDao extends AbstractDao implements LiveDataDao {
     protected JavaLiveDataDao(@NonNull final SQLiteOpenHelper helper) {
         super(helper);
-    }
-
-    private final LiveDataRegistry mLiveDataRegistry = new LiveDataRegistry();
-
-    @NotNull
-    @Override
-    public LiveDataRegistry getLiveDataRegistry() {
-        return mLiveDataRegistry;
     }
 
     private void insertMethods() {

--- a/gto-support-db-livedata/src/test/java/org/ccci/gto/android/common/db/LiveDataRegistryTest.kt
+++ b/gto-support-db-livedata/src/test/java/org/ccci/gto/android/common/db/LiveDataRegistryTest.kt
@@ -9,21 +9,23 @@ import kotlinx.coroutines.yield
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 class LiveDataRegistryTest {
     @get:Rule
     val instantTaskRule = InstantTaskExecutorRule()
 
-    private val registry = LiveDataRegistry()
-    lateinit var dao: LiveDataDao
+    private lateinit var dao: LiveDataDao
+    private lateinit var registry: LiveDataRegistry
 
     @Before
     fun setup() {
-        dao = mock()
-        whenever(dao.liveDataRegistry).thenReturn(registry)
-        whenever(dao.findLiveData(Obj::class.java)).thenCallRealMethod()
+        dao = mock {
+            registry = LiveDataRegistry(it)
+            on { liveDataRegistry } doReturn registry
+            on { findLiveData(Obj::class.java) }.thenCallRealMethod()
+        }
     }
 
     @Test


### PR DESCRIPTION
- utilize the service framework for the LiveDataRegistry
- s/coroutinesScope/coroutineScope
- restrict coroutineDispatcher and coroutineScope to subclasses only
