### PR TITLE
Fix Okta signout not actually signing out

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -96,6 +96,7 @@ scarlet-messageadapter-builtin = { module = "com.tinder.scarlet:message-adapter-
 scarlet-messageadapter-moshi = { module = "com.tinder.scarlet:message-adapter-moshi", version.ref = "scarlet" }
 scarlet-websocket-okhttp = { module = "com.tinder.scarlet:websocket-okhttp", version.ref = "scarlet" }
 snowplow = "com.snowplowanalytics:snowplow-android-tracker:3.0.3"
+splitties-bitflags = "com.louiscad.splitties:splitties-bitflags:3.0.0"
 timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
 weakdelegate = { module = "com.github.Karumi:WeakDelegate", version = "1.0.1" }
 

--- a/gto-support-okta/build.gradle.kts
+++ b/gto-support-okta/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(project(":gto-support-compat"))
     implementation(project(":gto-support-util"))
 
+    implementation(libs.splitties.bitflags)
     implementation(libs.timber)
 
     // region Coroutines

--- a/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/clients/web/SyncWebAuthClient+Coroutines.kt
+++ b/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/clients/web/SyncWebAuthClient+Coroutines.kt
@@ -3,15 +3,18 @@ package org.ccci.gto.android.common.okta.oidc.clients.web
 import android.app.Activity
 import com.okta.oidc.clients.AuthAPI
 import com.okta.oidc.clients.BaseAuth
+import com.okta.oidc.clients.BaseAuth.REMOVE_TOKENS
 import com.okta.oidc.clients.isCancelled
 import com.okta.oidc.clients.resetCurrentStateInt
 import com.okta.oidc.clients.web.SyncWebAuthClient
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import org.ccci.gto.android.common.compat.app.registerActivityLifecycleCallbacksCompat
 import org.ccci.gto.android.common.compat.app.unregisterActivityLifecycleCallbacksCompat
 import org.ccci.gto.android.common.util.app.EmptyActivityLifecycleCallbacks
+import splitties.bitflags.hasFlag
 
 suspend fun SyncWebAuthClient.signOutSuspending(activity: Activity, flags: Int = BaseAuth.ALL): Int {
     val callbacks = object : EmptyActivityLifecycleCallbacks() {
@@ -34,6 +37,7 @@ suspend fun SyncWebAuthClient.signOutSuspending(activity: Activity, flags: Int =
             }
         }
     } finally {
+        if (flags.hasFlag(REMOVE_TOKENS)) withContext(Dispatchers.Default + NonCancellable) { sessionClient.clear() }
         activity.unregisterActivityLifecycleCallbacksCompat(callbacks)
     }
 }

--- a/gto-support-okta/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/clients/web/SyncWebAuthClientCoroutinesTest.kt
+++ b/gto-support-okta/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/clients/web/SyncWebAuthClientCoroutinesTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.okta.oidc.clients.BaseAuth
+import com.okta.oidc.clients.sessions.SyncSessionClient
 import com.okta.oidc.clients.web.SyncWebAuthClient
 import java.util.concurrent.CountDownLatch
 import kotlinx.coroutines.Dispatchers
@@ -24,6 +25,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -40,11 +42,14 @@ class SyncWebAuthClientCoroutinesTest {
     private var signOutCompleted = false
 
     private lateinit var client: SyncWebAuthClient
+    private val sessionClient = mock<SyncSessionClient>()
     private val testScope = TestCoroutineScope(Job())
 
     @Before
     fun setup() {
         client = mock {
+            on { sessionClient } doReturn sessionClient
+
             var cancelled = false
 
             on { signOut(any(), any()) } doAnswer {
@@ -77,6 +82,8 @@ class SyncWebAuthClientCoroutinesTest {
                 assertEquals(BaseAuth.SUCCESS, signOut.await())
                 assertTrue(signOutCompleted)
                 verify(client).signOut(any(), any())
+                verify(client).sessionClient
+                verify(sessionClient).clear()
                 verifyNoMoreInteractions(client)
             }
         }
@@ -94,6 +101,8 @@ class SyncWebAuthClientCoroutinesTest {
                 assertFalse(signOutCompleted)
                 verify(client).signOut(any(), any())
                 verify(client).cancel()
+                verify(client).sessionClient
+                verify(sessionClient).clear()
                 verifyNoMoreInteractions(client)
             }
         }
@@ -111,6 +120,8 @@ class SyncWebAuthClientCoroutinesTest {
                 assertFalse(signOutCompleted)
                 verify(client).signOut(any(), any())
                 verify(client).cancel()
+                verify(client).sessionClient
+                verify(sessionClient).clear()
                 verifyNoMoreInteractions(client)
             }
         }
@@ -127,6 +138,8 @@ class SyncWebAuthClientCoroutinesTest {
         assertFalse(signOutCompleted)
         verify(client).signOut(any(), any())
         verify(client).cancel()
+        verify(client).sessionClient
+        verify(sessionClient).clear()
         verifyNoMoreInteractions(client)
     }
 

--- a/gto-support-okta/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/clients/web/SyncWebAuthClientCoroutinesTest.kt
+++ b/gto-support-okta/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/clients/web/SyncWebAuthClientCoroutinesTest.kt
@@ -27,6 +27,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 
@@ -84,6 +85,21 @@ class SyncWebAuthClientCoroutinesTest {
                 verify(client).signOut(any(), any())
                 verify(client).sessionClient
                 verify(sessionClient).clear()
+                verifyNoMoreInteractions(client)
+            }
+        }
+    }
+
+    @Test(timeout = 5000)
+    fun `signOutSuspending() - Don't REMOVE_TOKENS`() {
+        activityScenario.scenario.onActivity {
+            runBlocking {
+                val signOut = async(Dispatchers.IO) { client.signOutSuspending(it, BaseAuth.SIGN_OUT_SESSION ) }
+                clearAllLatches()
+                assertEquals(BaseAuth.SUCCESS, signOut.await())
+                assertTrue(signOutCompleted)
+                verify(client).signOut(any(), any())
+                verify(sessionClient, never()).clear()
                 verifyNoMoreInteractions(client)
             }
         }


### PR DESCRIPTION
- always clear the sessionClient when logging out
- add unit test to make sure we don't clear tokens unless we requested it
