### PR TITLE
GT-1423 Fix a dispatcher deadlock caused by using runBlocking

### DIFF
--- a/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -173,12 +173,17 @@ class ReadWriteMutexTest {
                 val running = AtomicBoolean(true)
                 val tasks = List(16) {
                     launch(Dispatchers.IO) {
-                        do {
+                        while (running.get()) {
                             try {
                                 mutex.read.unlock()
                             } catch (_: IllegalStateException) {
                             }
-                        } while (running.get())
+                        }
+                        // try unlocking one last time after stopping the loop to avoid a race condition
+                        try {
+                            mutex.read.unlock()
+                        } catch (_: IllegalStateException) {
+                        }
                     }
                 }
                 mutex.read.lock()

--- a/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -131,7 +131,7 @@ class ReadWriteMutexTest {
     @Test(expected = IllegalStateException::class)
     fun testReadLockTooManyTimes() {
         runBlocking {
-            (mutex as ReadWriteMutexImpl).readers = Long.MAX_VALUE
+            (mutex as ReadWriteMutexImpl).readers.set(Long.MAX_VALUE)
             mutex.read.lock()
         }
     }
@@ -149,10 +149,10 @@ class ReadWriteMutexTest {
             expect(1)
             mutex.read.lock()
             assertTrue(mutex.write.isLocked)
-            assertEquals(1, (mutex as ReadWriteMutexImpl).readers)
+            assertEquals(1, (mutex as ReadWriteMutexImpl).readers.get())
             expect(4)
             mutex.read.unlock()
-            assertEquals(0, mutex.readers)
+            assertEquals(0, mutex.readers.get())
         }
         expect(2)
 
@@ -160,7 +160,7 @@ class ReadWriteMutexTest {
             // this can cause a deadlock when runBlocking is being used
             mutex.read.unlock()
         }
-        assertEquals(0, (mutex as ReadWriteMutexImpl).readers)
+        assertEquals(0, (mutex as ReadWriteMutexImpl).readers.get())
         expect(3)
 
         mutex.write.unlock()
@@ -184,7 +184,7 @@ class ReadWriteMutexTest {
                 mutex.read.lock()
                 running.set(false)
                 tasks.joinAll()
-                assertEquals(0, (mutex as ReadWriteMutexImpl).readers)
+                assertEquals(0, (mutex as ReadWriteMutexImpl).readers.get())
             }
         }
     }

--- a/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -129,16 +129,14 @@ class ReadWriteMutexTest {
     @Test(expected = IllegalStateException::class)
     fun testReadLockTooManyTimes() {
         runBlocking {
-            (mutex as ReadWriteMutexImpl).readers = Long.MAX_VALUE - 1
-            while (true) mutex.read.lock()
+            (mutex as ReadWriteMutexImpl).readers = Long.MAX_VALUE
+            mutex.read.lock()
         }
     }
 
     @Test(expected = IllegalStateException::class)
     fun testInvalidReadUnlock() {
-        runBlocking {
-            mutex.read.unlock()
-        }
+        mutex.read.unlock()
     }
 
     @Test

--- a/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ReadWriteMutexTest {
@@ -137,6 +139,31 @@ class ReadWriteMutexTest {
     @Test(expected = IllegalStateException::class)
     fun testInvalidReadUnlock() {
         mutex.read.unlock()
+    }
+
+    @Test(timeout = 10000)
+    fun `GT-1423 readUnlock causes deadlock from runBlocking usage`() = runBlocking {
+        mutex.write.lock()
+
+        launch(Dispatchers.Unconfined) {
+            expect(1)
+            mutex.read.lock()
+            assertTrue(mutex.write.isLocked)
+            assertEquals(1, (mutex as ReadWriteMutexImpl).readers)
+            expect(4)
+            mutex.read.unlock()
+            assertEquals(0, mutex.readers)
+        }
+        expect(2)
+
+        assertThrows(IllegalStateException::class.java) {
+            // this can cause a deadlock when runBlocking is being used
+            mutex.read.unlock()
+        }
+        assertEquals(0, (mutex as ReadWriteMutexImpl).readers)
+        expect(3)
+
+        mutex.write.unlock()
     }
 
     @Test


### PR DESCRIPTION
This PR is to fix a deadlock caused by `runBlocking` deadlocking the dispatcher by waiting for a different lock to be released.

- `runBlocking` locks the current thread to the `runBlocking` call and doesn't allow the thread to be used by other coroutines.
- executing `mutex.read.unlock()` on a coroutines dispatcher thread will block that thread and prevent it from being used by other coroutines until `unlock()` finishes
- if `unlock()` has to wait for the `stateMutex` to be released by another coroutine it could deadlock if there are no remaining dispatcher threads to process other coroutines

This could all combine to a deadlock scenario if there is high volume locking/unlocking happening on a `ReadWriteMutex`