### PR TITLE
GT-1440 Fix another ReadWriteMutex race condition

### DIFF
--- a/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
+++ b/gto-support-kotlin-coroutines/src/test/kotlin/org/ccci/gto/android/common/kotlin/coroutines/ReadWriteMutexTest.kt
@@ -175,7 +175,7 @@ class ReadWriteMutexTest {
         withContext(Dispatchers.IO) {
             repeat(2) {
                 launch {
-                    repeat(10000) {
+                    repeat(40000) {
                         mutex.read.lock()
                         yield()
                         mutex.read.unlock()


### PR DESCRIPTION
There was a race condition when one thread was releasing the last read lock at the same time as another thread was acquiring a new read lock.