### PR TITLE
GT-1432 LiveData Menu observer

### DIFF
--- a/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+Menu.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+Menu.kt
@@ -1,0 +1,12 @@
+package org.ccci.gto.android.common.androidx.lifecycle
+
+import android.view.Menu
+import android.view.MenuItem
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+
+fun <T> LiveData<T>.observe(lifecycleOwner: LifecycleOwner, menu: Menu, observer: Menu.(T) -> Unit) =
+    observeWeak(lifecycleOwner, menu, observer)
+
+fun <T> LiveData<T>.observe(lifecycleOwner: LifecycleOwner, item: MenuItem, observer: MenuItem.(T) -> Unit) =
+    observeWeak(lifecycleOwner, item, observer)

--- a/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/WeakObserver.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/WeakObserver.kt
@@ -1,0 +1,26 @@
+package org.ccci.gto.android.common.androidx.lifecycle
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import com.karumi.weak.WeakReferenceDelegate
+import com.karumi.weak.weak
+
+internal fun <O : Any, T> LiveData<T>.observeWeak(
+    lifecycleOwner: LifecycleOwner,
+    obj: O,
+    observer: O.(T) -> Unit
+): Observer<T> = WeakObserver(this, obj, observer).also { observe(lifecycleOwner, it) }
+
+private class WeakObserver<O : Any, T>(liveData: LiveData<T>, obj: O, private val observer: O.(T) -> Unit) :
+    Observer<T> {
+    private val liveData by weak(liveData)
+    private val obj by WeakReferenceDelegate(obj)
+
+    override fun onChanged(t: T) {
+        when (val obj = obj) {
+            null -> liveData?.removeObserver(this)
+            else -> obj.observer(t)
+        }
+    }
+}

--- a/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/WeakObserverTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/WeakObserverTest.kt
@@ -1,0 +1,71 @@
+package org.ccci.gto.android.common.androidx.lifecycle
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.testing.TestLifecycleOwner
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WeakObserverTest : BaseLiveDataTest() {
+    var counter = 0
+    val liveData = MutableLiveData(counter)
+
+    private val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = UnconfinedTestDispatcher())
+
+    @Test
+    fun `remove observer manually`() {
+        val obj = Any()
+        assertFalse(liveData.hasActiveObservers())
+        val observer = liveData.observeWeak(lifecycleOwner, obj) { counter++ }
+        assertTrue(liveData.hasActiveObservers())
+        assertEquals(1, counter)
+
+        liveData.value = counter
+        assertEquals(2, counter)
+
+        liveData.removeObserver(observer)
+        liveData.value = counter
+        assertFalse(liveData.hasActiveObservers())
+        assertEquals(2, counter)
+    }
+
+    @Test
+    fun `remove observer automatically when obj is garbage collected`() {
+        var obj = Any()
+        assertFalse(liveData.hasActiveObservers())
+        liveData.observeWeak(lifecycleOwner, obj) { counter++ }
+        assertTrue(liveData.hasActiveObservers())
+        assertEquals(1, counter)
+
+        liveData.value = counter
+        assertEquals(2, counter)
+
+        obj = Any()
+        System.gc()
+        liveData.value = counter
+        assertFalse(liveData.hasActiveObservers())
+        assertEquals(2, counter)
+    }
+
+    @Test
+    fun `remove observer automatically when lifecycle is destroyed`() {
+        val obj = Any()
+        assertFalse(liveData.hasActiveObservers())
+        liveData.observeWeak(lifecycleOwner, obj) { counter++ }
+        assertTrue(liveData.hasActiveObservers())
+        assertEquals(1, counter)
+
+        liveData.value = counter
+        assertEquals(2, counter)
+
+        lifecycleOwner.currentState = Lifecycle.State.DESTROYED
+        liveData.value = counter
+        assertFalse(liveData.hasActiveObservers())
+        assertEquals(2, counter)
+    }
+}


### PR DESCRIPTION
This will allow us to observe a LiveData as long as the menu still exists.