### PR TITLE
cleanup

### DIFF
--- a/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+ViewModel.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+ViewModel.kt
@@ -1,0 +1,29 @@
+package org.ccci.gto.android.common.androidx.lifecycle
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.setTagIfAbsent
+import com.karumi.weak.weak
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicInteger
+
+private val OBSERVER_INDEX = AtomicInteger(0)
+fun <T> LiveData<T>.observe(viewModel: ViewModel, onChanged: (T) -> Unit): Observer<T> {
+    val observer = Observer<T> { t -> onChanged.invoke(t) }
+    observeForever(observer)
+    viewModel.setTagIfAbsent(
+        "LiveDataObserver-${OBSERVER_INDEX.getAndIncrement()}",
+        WeakCloseableObserverWrapper(this, observer)
+    )
+    return observer
+}
+
+private class WeakCloseableObserverWrapper<T>(liveData: LiveData<T>, observer: Observer<T>) : Closeable {
+    private val liveData: LiveData<T>? by weak(liveData)
+    private val observer: Observer<T>? by weak(observer)
+
+    override fun close() {
+        observer?.let { liveData?.removeObserver(it) }
+    }
+}

--- a/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData.kt
@@ -4,11 +4,6 @@ import androidx.annotation.MainThread
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.setTagIfAbsent
-import com.karumi.weak.weak
-import java.io.Closeable
-import java.util.concurrent.atomic.AtomicInteger
 
 @MainThread
 inline fun <T> LiveData<T>.observeOnce(owner: LifecycleOwner, crossinline onChanged: (T) -> Unit) =
@@ -23,25 +18,5 @@ inline fun <T> LiveData<T>.observeOnceObserver(crossinline onChanged: (T) -> Uni
     override fun onChanged(t: T) {
         onChanged.invoke(t)
         removeObserver(this)
-    }
-}
-
-private val OBSERVER_INDEX = AtomicInteger(0)
-fun <T> LiveData<T>.observe(viewModel: ViewModel, onChanged: (T) -> Unit): Observer<T> {
-    val observer = Observer<T> { t -> onChanged.invoke(t) }
-    observeForever(observer)
-    viewModel.setTagIfAbsent(
-        "LiveDataObserver-${OBSERVER_INDEX.getAndIncrement()}",
-        WeakCloseableObserverWrapper(this, observer)
-    )
-    return observer
-}
-
-private class WeakCloseableObserverWrapper<T>(liveData: LiveData<T>, observer: Observer<T>) : Closeable {
-    private val liveData: LiveData<T>? by weak(liveData)
-    private val observer: Observer<T>? by weak(observer)
-
-    override fun close() {
-        observer?.let { liveData?.removeObserver(it) }
     }
 }

--- a/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/ConstrainedStateLifecycleOwnerTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/ConstrainedStateLifecycleOwnerTest.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -21,7 +21,7 @@ class ConstrainedStateLifecycleOwnerTest {
     val rule = InstantTaskExecutorRule()
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private val parentLifecycleOwner = TestLifecycleOwner(Lifecycle.State.STARTED, TestCoroutineDispatcher())
+    private val parentLifecycleOwner = TestLifecycleOwner(Lifecycle.State.STARTED, UnconfinedTestDispatcher())
     private lateinit var observer: DefaultLifecycleObserver
 
     private lateinit var lifecycleOwner: ConstrainedStateLifecycleOwner

--- a/gto-support-androidx-viewpager2/src/main/java/org/ccci/gto/android/common/androidx/viewpager2/widget/ViewPager2.kt
+++ b/gto-support-androidx-viewpager2/src/main/java/org/ccci/gto/android/common/androidx/viewpager2/widget/ViewPager2.kt
@@ -24,6 +24,7 @@ fun ViewPager2.whileMaintainingVisibleCurrentItem(block: (RecyclerView.Adapter<*
     }
 }
 
+@Suppress("UNCHECKED_CAST")
 val ViewPager2.currentItemLiveData: LiveData<Int>
     get() = getTag(R.id.viewpager2_livedata_currentitem) as? LiveData<Int> ?: object : LiveData<Int>(currentItem) {
         val callbacks = object : ViewPager2.OnPageChangeCallback() {

--- a/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/RequestCreatorCoroutines.kt
+++ b/gto-support-picasso/src/main/java/org/ccci/gto/android/common/picasso/RequestCreatorCoroutines.kt
@@ -9,20 +9,18 @@ import com.squareup.picasso.picasso
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CancellableContinuation
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 
-suspend fun RequestCreator.getBitmap(): Bitmap = withContext(Dispatchers.Main) {
+suspend fun RequestCreator.getBitmap(): Bitmap = withContext(Dispatchers.Main.immediate) {
     suspendCancellableCoroutine { cont ->
         val target = BitmapContinuationTarget(cont)
         into(target)
         cont.invokeOnCancellation {
-            @OptIn(DelicateCoroutinesApi::class)
-            GlobalScope.launch(Dispatchers.Main.immediate) { picasso?.cancelRequest(target) }
+            launch(NonCancellable) { picasso?.cancelRequest(target) }
         }
     }
 }

--- a/gto-support-picasso/src/test/kotlin/org/ccci/gto/android/common/picasso/RequestCreatorTest.kt
+++ b/gto-support-picasso/src/test/kotlin/org/ccci/gto/android/common/picasso/RequestCreatorTest.kt
@@ -10,21 +10,19 @@ import com.squareup.picasso.StubRequestCreator
 import com.squareup.picasso.Target
 import java.lang.ref.Reference
 import java.lang.ref.WeakReference
-import java.util.concurrent.Executors
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.android.asCoroutineDispatcher
-import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -40,92 +38,78 @@ import org.mockito.kotlin.whenever
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class RequestCreatorTest {
-    private lateinit var request: RequestCreator
-    private lateinit var dispatcher: ExecutorCoroutineDispatcher
-    private lateinit var testDispatcher: TestCoroutineDispatcher
-
+    private lateinit var mainThread: HandlerThread
     private lateinit var bitmap: Bitmap
+    private lateinit var request: RequestCreator
 
     @Before
     fun setup() {
-        request = mock()
-        dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-        testDispatcher = TestCoroutineDispatcher()
-        Dispatchers.setMain(testDispatcher)
+        mainThread = HandlerThread("").apply { start() }
+        Dispatchers.setMain(Handler(mainThread.looper).asCoroutineDispatcher())
 
         bitmap = mock()
+        request = mock()
     }
 
     @After
     fun cleanup() {
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
+        mainThread.quit()
+        mainThread.join()
     }
 
     @Test
-    fun testGetBitmap() {
+    fun testGetBitmap() = runTest {
         whenever(request.into(any<Target>()))
             .thenAnswer { it.getArgument<Target>(0).onBitmapLoaded(bitmap, Picasso.LoadedFrom.DISK) }
 
-        assertSame(bitmap, runBlocking { request.getBitmap() })
+        assertSame(bitmap, request.getBitmap())
     }
 
     @Test(expected = ExpectedException::class)
-    fun testGetBitmapError() {
+    fun testGetBitmapError() = runTest {
         whenever(request.into(any<Target>()))
             .thenAnswer { it.getArgument<Target>(0).onBitmapFailed(ExpectedException(), null) }
 
-        runBlocking { request.getBitmap() }
+        request.getBitmap()
     }
 
     @Test
-    fun testGetBitmapMainThreadUsage() {
-        val thread = HandlerThread("").apply { start() }
-        Dispatchers.setMain(Handler(thread.looper).asCoroutineDispatcher())
+    fun testGetBitmapMainThreadUsage() = runTest {
         whenever(request.into(any<Target>())).thenAnswer {
-            check(thread === Thread.currentThread()) { "Not executing on the Main Thread" }
+            assertSame("Not executing on the Main Thread", mainThread, Thread.currentThread())
             it.getArgument<Target>(0).onBitmapLoaded(bitmap, Picasso.LoadedFrom.DISK)
         }
 
-        runBlocking {
-            launch(Dispatchers.Default) { request.getBitmap() }
-            request.getBitmap()
-        }
-        thread.quit()
+        assertNotSame(mainThread, Thread.currentThread())
+        request.getBitmap()
     }
 
     @Test(timeout = 5000)
-    fun `getBitmap() should protect it's target from garbage collection`() {
+    fun `getBitmap() should protect it's target from garbage collection`() = runTest {
         val request = TargetCapturingRequestCreator()
-        runBlocking {
-            val task = launch(Dispatchers.Default) { request.getBitmap() }
-            val ref = request.targets.receive()
-            System.gc()
-            val target = ref.get()
-            if (target == null) task.cancel()
-            assertNotNull(target)
-            target!!.onBitmapLoaded(bitmap, Picasso.LoadedFrom.DISK)
-        }
+        val task = launch { request.getBitmap() }
+        val ref = request.targets.receive()
+        System.gc()
+        val target = ref.get()
+        if (target == null) task.cancel()
+        assertNotNull(target)
+        target!!.onBitmapLoaded(bitmap, Picasso.LoadedFrom.DISK)
     }
 
     @Test
-    fun `getBitmap() should cancel Picasso request on task cancellation`() {
+    fun `getBitmap() should cancel Picasso request on task cancellation`() = runTest {
         val picasso = mock<Picasso>()
         val request = TargetCapturingRequestCreator(picasso)
-        val target = runBlocking {
-            val task = launch(Dispatchers.Default) { request.getBitmap() }
-            val target = request.targets.receive().get()!!
-            task.cancel()
-            return@runBlocking target
-        }
+
+        val task = launch { request.getBitmap() }
+        val target = request.targets.receive().get()!!
+        task.cancelAndJoin()
         verify(picasso).cancelRequest(target)
     }
 
     @Test
-    fun `getBitmap() should cancel Picasso request on main thread`() {
-        val thread = HandlerThread("").apply { start() }
-        assertTrue(thread.isAlive)
-        Dispatchers.setMain(Handler(thread.looper).asCoroutineDispatcher())
+    fun `getBitmap() should cancel Picasso request on main thread`() = runTest {
         var cancelRequestThread: Thread? = null
         val picasso = mock<Picasso> {
             // we capture the thread that cancelRequest is called on, that way we can assert later that it was the
@@ -138,15 +122,10 @@ class RequestCreatorTest {
         }
 
         val request = TargetCapturingRequestCreator(picasso)
-        val target = runBlocking {
-            val task = launch(TestCoroutineDispatcher()) { request.getBitmap() }
-            val target = request.targets.receive().get()!!
-            task.cancel()
-            return@runBlocking target
-        }
-        thread.quitSafely()
-        thread.join()
-        assertEquals(thread, cancelRequestThread)
+        val task = launch(UnconfinedTestDispatcher()) { request.getBitmap() }
+        val target = request.targets.receive().get()!!
+        task.cancelAndJoin()
+        assertSame(mainThread, cancelRequestThread)
         verify(picasso).cancelRequest(target)
         verifyNoMoreInteractions(picasso)
     }

--- a/gto-support-util/src/main/java/org/ccci/gto/android/common/util/graphics/HsvColor.kt
+++ b/gto-support-util/src/main/java/org/ccci/gto/android/common/util/graphics/HsvColor.kt
@@ -5,7 +5,8 @@ import androidx.annotation.ColorInt
 import androidx.annotation.Size
 import kotlin.math.min
 
-inline class HsvColor(@Size(3) internal val hsv: FloatArray = FloatArray(3)) {
+@JvmInline
+value class HsvColor(@Size(3) internal val hsv: FloatArray = FloatArray(3)) {
     constructor(hue: Float, saturation: Float, value: Float) : this(arrayOf(hue, saturation, value).toFloatArray())
 
     val hue get() = hsv[0]


### PR DESCRIPTION
- move LiveData ViewModel extensions to separate source file for organization
- make HsvColor a value class
- use the UnconfinedTestDispatcher for ConstraintedStateLifecycleOwnerTest
- utilize new kotlin coroutines runTest method
- handle cancellation within the local CoroutineScope
- cleanup RequestCreatorTest to better leverage kotlin coroutines test
- suppress the unchecked cast
