### PR TITLE
ViewModel LiveData multi-observe

### DIFF
--- a/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+ViewModel.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+ViewModel.kt
@@ -9,8 +9,7 @@ import java.io.Closeable
 import java.util.concurrent.atomic.AtomicInteger
 
 private val OBSERVER_INDEX = AtomicInteger(0)
-fun <T> LiveData<T>.observe(viewModel: ViewModel, onChanged: (T) -> Unit): Observer<T> {
-    val observer = Observer<T> { t -> onChanged.invoke(t) }
+fun <O, T : O> LiveData<T>.observe(viewModel: ViewModel, observer: Observer<O>): Observer<O> {
     observeForever(observer)
     viewModel.setTagIfAbsent(
         "LiveDataObserver-${OBSERVER_INDEX.getAndIncrement()}",
@@ -19,9 +18,9 @@ fun <T> LiveData<T>.observe(viewModel: ViewModel, onChanged: (T) -> Unit): Obser
     return observer
 }
 
-private class WeakCloseableObserverWrapper<T>(liveData: LiveData<T>, observer: Observer<T>) : Closeable {
+private class WeakCloseableObserverWrapper<T>(liveData: LiveData<T>, observer: Observer<in T>) : Closeable {
     private val liveData: LiveData<T>? by weak(liveData)
-    private val observer: Observer<T>? by weak(observer)
+    private val observer: Observer<in T>? by weak(observer)
 
     override fun close() {
         observer?.let { liveData?.removeObserver(it) }

--- a/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+ViewModel.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+ViewModel.kt
@@ -26,3 +26,24 @@ private class WeakCloseableObserverWrapper<T>(liveData: LiveData<T>, observer: O
         observer?.let { liveData?.removeObserver(it) }
     }
 }
+
+// region Multi-observe
+fun <IN1, IN2> ViewModel.observe(
+    source1: LiveData<IN1>,
+    source2: LiveData<IN2>,
+    observer: (IN1, IN2) -> Unit
+) = compoundLiveData(source1, source2).observe(this) {
+    @Suppress("UNCHECKED_CAST")
+    observer(source1.value as IN1, source2.value as IN2)
+}
+
+fun <IN1, IN2, IN3> ViewModel.observe(
+    source1: LiveData<IN1>,
+    source2: LiveData<IN2>,
+    source3: LiveData<IN3>,
+    observer: (IN1, IN2, IN3) -> Unit
+) = compoundLiveData(source1, source2, source3).observe(this) {
+    @Suppress("UNCHECKED_CAST")
+    observer(source1.value as IN1, source2.value as IN2, source3.value as IN3)
+}
+// endregion Multi-observe

--- a/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData.kt
@@ -45,7 +45,7 @@ fun <IN1, IN2, IN3> observeForever(
     observer(source1.value as IN1, source2.value as IN2, source3.value as IN3)
 }
 
-private fun compoundLiveData(vararg input: LiveData<*>): LiveData<Unit> {
+internal fun compoundLiveData(vararg input: LiveData<*>): LiveData<Unit> {
     val result = MediatorLiveData<Unit>()
     val state = object {
         val inputInitialized = BooleanArray(input.size) { false }

--- a/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveDataViewModelObserverTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveDataViewModelObserverTest.kt
@@ -4,9 +4,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.clear
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 
@@ -45,4 +48,40 @@ class LiveDataViewModelObserverTest : BaseLiveDataTest() {
         liveData.value = 2
         verifyNoMoreInteractions(observer)
     }
+
+    // region Multi-observe
+    private val data2 = MutableLiveData<String>()
+    private val data3 = MutableLiveData<Long>()
+
+    @Test
+    fun `observe() - 2 LiveDatas`() {
+        viewModel.observe(liveData, data2) { t1, t2 -> observer.onChanged("$t1 $t2") }
+
+        liveData.value = 1
+        data2.value = "a"
+        liveData.value = 2
+        data2.value = "b"
+        argumentCaptor<String> {
+            verify(observer, times(3)).onChanged(capture())
+            verifyNoMoreInteractions(observer)
+            assertEquals(listOf("1 a", "2 a", "2 b"), allValues)
+        }
+    }
+
+    @Test
+    fun `observe() - 3 LiveDatas`() {
+        viewModel.observe(liveData, data2, data3) { d1, d2, d3 -> observer.onChanged("$d1 $d2 $d3") }
+        liveData.value = 1
+        data2.value = "a"
+        data3.value = 100
+        liveData.value = 2
+        data2.value = "b"
+        data3.value = 200
+        argumentCaptor<String> {
+            verify(observer, times(4)).onChanged(capture())
+            verifyNoMoreInteractions(observer)
+            assertEquals(listOf("1 a 100", "2 a 100", "2 b 100", "2 b 200"), allValues)
+        }
+    }
+    // endregion Multi-observe
 }

--- a/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveDataViewModelObserverTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveDataViewModelObserverTest.kt
@@ -1,31 +1,22 @@
 package org.ccci.gto.android.common.androidx.lifecycle
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.clear
 import org.junit.After
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
 
-class LiveDataViewModelObserverTest {
-    @get:Rule
-    val instantTaskRule = InstantTaskExecutorRule()
-
+class LiveDataViewModelObserverTest : BaseLiveDataTest() {
     private val liveData = MutableLiveData<Int>()
     private lateinit var viewModel: ViewModel
-    private lateinit var onChanged: (Int) -> Unit
 
     @Before
     fun setup() {
         viewModel = object : ViewModel() {}
-        onChanged = mock()
     }
 
     @After
@@ -35,25 +26,23 @@ class LiveDataViewModelObserverTest {
 
     @Test
     fun verifyLiveDataViewModelObserver() {
-        liveData.observe(viewModel, onChanged)
+        liveData.observe(viewModel, observer)
         liveData.value = 1
-        verify(onChanged).invoke(any())
+        verify(observer).onChanged(any())
 
-        reset(onChanged)
         viewModel.clear()
         liveData.value = 2
-        verify(onChanged, never()).invoke(any())
+        verifyNoMoreInteractions(observer)
     }
 
     @Test
     fun verifyLiveDataViewModelObserverCanBeRemoved() {
-        val observer = liveData.observe(viewModel, onChanged)
+        val resp = liveData.observe(viewModel, observer)
         liveData.value = 1
-        verify(onChanged).invoke(any())
+        verify(observer).onChanged(any())
 
-        reset(onChanged)
-        liveData.removeObserver(observer)
+        liveData.removeObserver(resp)
         liveData.value = 2
-        verify(onChanged, never()).invoke(any())
+        verifyNoMoreInteractions(observer)
     }
 }


### PR DESCRIPTION
- directly use the Observer interface for ViewModel observers
- support multi-observe on a ViewModel
