### PR TITLE
Publish SNAPSHOT builds for open PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,16 +6,11 @@ on:
   pull_request:
     branches: [master]
 
-jobs:
-  cancel-previous:
-    name: Cancel Stale In-progress Builds
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   static:
     name: Static Analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ORG_GRADLE_PROJECT_releaseBuild: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
+  ORG_GRADLE_PROJECT_versionSuffix: ${{ (github.event_name == 'pull_request' && format('PR{0}', github.event.pull_request.number)) || '' }}
+
 jobs:
   static:
     name: Static Analysis
@@ -63,10 +67,10 @@ jobs:
           name: unit-test-results
           path: "**/build/reports/tests/"
 
-  deploy_snapshot:
-    name: Deploy Library Snapshot
+  deploy:
+    name: Deploy Library
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/')))
     needs: [static, tests]
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -70,7 +73,11 @@ jobs:
   deploy:
     name: Deploy Library
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/')))
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/')))
     needs: [static, tests]
     steps:
       - name: Checkout code

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,13 @@ plugins {
 }
 
 allprojects {
-    version = "3.11.2-SNAPSHOT"
+    // configure the project version
+    if (!project.findProperty("releaseBuild")?.toString().toBoolean()) {
+        project.findProperty("versionSuffix")?.toString()
+            ?.takeIf { it.matches(Regex("\\S+")) }
+            ?.let { version = "$version-$it" }
+        version = "$version-SNAPSHOT"
+    }
 
     repositories {
         maven {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+version=3.11.2
+
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true


### PR DESCRIPTION
- make it possible to customize the version when building
- use workflow concurrency to cancel previous executions
- publish snapshots and release builds on tags and PRs
- schedule a SNAPSHOT build once a month and add support for manually triggering a build
