### PR TITLE
Prepare for AndroidX Lifecycle 2.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.11.2
+version=3.12.0
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g

--- a/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/SavedStateHandle+StateFlow.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/SavedStateHandle+StateFlow.kt
@@ -12,7 +12,18 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
 
 @MainThread
+@Deprecated(
+    "Since v3.12.0, use getMutableStateFlow() or the official getStateFlow in Lifecycle 2.5.0",
+    ReplaceWith("getMutableStateFlow(scope, key, initialValue)")
+)
 fun <T> SavedStateHandle.getStateFlow(
+    scope: CoroutineScope,
+    key: String,
+    initialValue: T
+): MutableStateFlow<T> = getMutableStateFlow(scope, key, initialValue)
+
+@MainThread
+fun <T> SavedStateHandle.getMutableStateFlow(
     scope: CoroutineScope,
     key: String,
     initialValue: T

--- a/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/SavedStateHandleStateFlowTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/SavedStateHandleStateFlowTest.kt
@@ -40,12 +40,12 @@ class SavedStateHandleStateFlowTest {
     }
 
     @Test
-    fun `getStateFlow() - updating value`() = runTest {
+    fun `getMutableStateFlow() - updating value`() = runTest {
         val flowScope = TestScope(StandardTestDispatcher())
         assertNull(savedStateHandle[KEY])
 
         val liveData = savedStateHandle.getLiveData<String?>(KEY)
-        val stateFlow = savedStateHandle.getStateFlow<String?>(flowScope, KEY, "initial")
+        val stateFlow = savedStateHandle.getMutableStateFlow<String?>(flowScope, KEY, "initial")
         assertEquals("initial", stateFlow.value)
 
         // update key directly
@@ -70,7 +70,7 @@ class SavedStateHandleStateFlowTest {
     }
 
     @Test
-    fun `getStateFlow() - uses MainDispatcher for syncing updates`() = runTest {
+    fun `getMutableStateFlow() - uses MainDispatcher for syncing updates`() = runTest {
         val mainDispatcher = StandardTestDispatcher()
         Dispatchers.setMain(mainDispatcher)
 
@@ -78,7 +78,7 @@ class SavedStateHandleStateFlowTest {
         assertNull(savedStateHandle[KEY])
 
         val liveData = savedStateHandle.getLiveData<String?>(KEY)
-        val stateFlow = savedStateHandle.getStateFlow<String?>(flowScope, KEY, "initial")
+        val stateFlow = savedStateHandle.getMutableStateFlow<String?>(flowScope, KEY, "initial")
         assertEquals("initial", stateFlow.value)
 
         // update key directly
@@ -106,11 +106,11 @@ class SavedStateHandleStateFlowTest {
     }
 
     @Test
-    fun `getStateFlow() - don't overwrite existing value`() = runTest {
+    fun `getMutableStateFlow() - don't overwrite existing value`() = runTest {
         val flowScope = TestScope(StandardTestDispatcher())
         savedStateHandle[KEY] = "already set"
 
-        val stateFlow = savedStateHandle.getStateFlow<String?>(flowScope, KEY, "initial")
+        val stateFlow = savedStateHandle.getMutableStateFlow<String?>(flowScope, KEY, "initial")
         assertEquals("already set", stateFlow.value)
 
         flowScope.cancel()


### PR DESCRIPTION
- bump gto-support version
- deprecate getStateFlow() extension if preparation for official getStateFlow support
