### PR TITLE
Expose a method to measure the height of text for a style

### DIFF
--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -62,8 +62,14 @@ fun CommonExtension<*, *, *, *>.configureCompose(project: Project) {
     composeOptions.kotlinCompilerExtensionVersion =
         project.libs.findVersion("androidx-compose-compiler").get().requiredVersion
 
-    // the runtime dependency is required to build a library when compose is enabled
-    project.dependencies.addProvider("implementation", project.libs.findLibrary("androidx-compose-runtime").get())
+    project.dependencies.apply {
+        // the runtime dependency is required to build a library when compose is enabled
+        addProvider("implementation", project.libs.findLibrary("androidx-compose-runtime").get())
+
+        // these dependencies are required for tests of Composables
+        addProvider("debugImplementation", project.libs.findBundle("androidx-compose-debug").get())
+        addProvider("testDebugImplementation", project.libs.findBundle("androidx-compose-testing").get())
+    }
 }
 
 private fun BaseExtension.configureTestOptions() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,8 @@ androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", ver
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "androidx-compose" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose" }
+androidx-compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-compose" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose" }
 androidx-concurrent-futures = { module = "androidx.concurrent:concurrent-futures", version = "1.1.0" }
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.4"
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
@@ -107,6 +109,8 @@ timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
 weakdelegate = { module = "com.github.Karumi:WeakDelegate", version = "1.0.1" }
 
 [bundles]
+androidx-compose-debug = ["androidx-compose-ui-test-manifest"]
+androidx-compose-testing = ["androidx-compose-ui-test"]
 okhttp3-mockwebserver = ["okhttp3-mockwebserver", "okhttp3-tls"]
 
 [plugins]

--- a/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/foundation/text/MinLinesHeightModifier.kt
+++ b/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/foundation/text/MinLinesHeightModifier.kt
@@ -1,30 +1,14 @@
 package org.ccci.gto.android.common.androidx.compose.foundation.text
 
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalFontFamilyResolver
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.debugInspectorInfo
-import androidx.compose.ui.text.Paragraph
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontSynthesis
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.resolveDefaults
-import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntSize
-import kotlin.math.ceil
-import kotlin.math.roundToInt
+import org.ccci.gto.android.common.androidx.compose.ui.text.computeHeightForDefaultText
 
 // Logic based on MaxLinesHeightModifier from Android Open Source Project.
-
-private const val EmptyTextReplacement = "HHHHHHHHHH"
 
 /**
  * Constraint the height of the text field so that it vertically occupies at least [minLines]
@@ -46,82 +30,15 @@ fun Modifier.minLinesHeight(
     require(minLines >= 0) { "minLines must be greater than or equal to 0" }
     if (minLines == 0) return@composed Modifier
 
-    val density = LocalDensity.current
-    val fontFamilyResolver = LocalFontFamilyResolver.current
-    val layoutDirection = LocalLayoutDirection.current
-
     // Difference between the height of two lines paragraph and one line paragraph gives us
     // an approximation of height of one line
-    val resolvedStyle = remember(textStyle, layoutDirection) {
-        resolveDefaults(textStyle, layoutDirection)
-    }
-    val typeface by remember(fontFamilyResolver, resolvedStyle) {
-        fontFamilyResolver.resolve(
-            resolvedStyle.fontFamily,
-            resolvedStyle.fontWeight ?: FontWeight.Normal,
-            resolvedStyle.fontStyle ?: FontStyle.Normal,
-            resolvedStyle.fontSynthesis ?: FontSynthesis.All
-        )
-    }
-
-    val firstLineHeight = remember(
-        density,
-        fontFamilyResolver,
-        textStyle,
-        layoutDirection,
-        typeface
-    ) {
-        computeSizeForDefaultText(
-            style = resolvedStyle,
-            density = density,
-            fontFamilyResolver = fontFamilyResolver,
-            text = EmptyTextReplacement,
-            maxLines = 1
-        ).height
-    }
-
-    val firstTwoLinesHeight = remember(
-        density,
-        fontFamilyResolver,
-        textStyle,
-        layoutDirection,
-        typeface
-    ) {
-        val twoLines = EmptyTextReplacement + "\n" + EmptyTextReplacement
-        computeSizeForDefaultText(
-            style = resolvedStyle,
-            density = density,
-            fontFamilyResolver = fontFamilyResolver,
-            text = twoLines,
-            maxLines = 2
-        ).height
-    }
+    val firstLineHeight = computeHeightForDefaultText(textStyle, 1)
+    val firstTwoLinesHeight = computeHeightForDefaultText(textStyle, 2)
     val lineHeight = firstTwoLinesHeight - firstLineHeight
     val precomputedMinLinesHeight = firstLineHeight + lineHeight * (minLines - 1)
 
+    val density = LocalDensity.current
     Modifier.heightIn(
         min = with(density) { precomputedMinLinesHeight.toDp() }
     )
 }
-
-private fun computeSizeForDefaultText(
-    style: TextStyle,
-    density: Density,
-    fontFamilyResolver: FontFamily.Resolver,
-    text: String = EmptyTextReplacement,
-    maxLines: Int = 1
-): IntSize {
-    val paragraph = Paragraph(
-        text = text,
-        style = style,
-        spanStyles = listOf(),
-        maxLines = maxLines,
-        ellipsis = false,
-        density = density,
-        fontFamilyResolver = fontFamilyResolver,
-        constraints = Constraints()
-    )
-    return IntSize(paragraph.minIntrinsicWidth.toIntPx(), paragraph.height.toIntPx())
-}
-
-private fun Float.toIntPx(): Int = ceil(this).roundToInt()

--- a/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/foundation/text/MinLinesHeightModifier.kt
+++ b/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/foundation/text/MinLinesHeightModifier.kt
@@ -3,7 +3,6 @@ package org.ccci.gto.android.common.androidx.compose.foundation.text
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.text.TextStyle
 import org.ccci.gto.android.common.androidx.compose.ui.text.computeHeightForDefaultText
@@ -37,8 +36,5 @@ fun Modifier.minLinesHeight(
     val lineHeight = firstTwoLinesHeight - firstLineHeight
     val precomputedMinLinesHeight = firstLineHeight + lineHeight * (minLines - 1)
 
-    val density = LocalDensity.current
-    Modifier.heightIn(
-        min = with(density) { precomputedMinLinesHeight.toDp() }
-    )
+    Modifier.heightIn(min = precomputedMinLinesHeight)
 }

--- a/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/Paragraph.kt
+++ b/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/Paragraph.kt
@@ -1,0 +1,87 @@
+package org.ccci.gto.android.common.androidx.compose.ui.text
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.Paragraph
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontSynthesis
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.resolveDefaults
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import kotlin.math.ceil
+import kotlin.math.roundToInt
+
+private const val EmptyTextReplacement = "HHHHHHHHHH"
+
+@Composable
+fun computeHeightForDefaultText(
+    textStyle: TextStyle,
+    lines: Int = 1
+): Int {
+    require(lines >= 0) { "Invalid number of lines: $lines" }
+
+    val density = LocalDensity.current
+    val fontFamilyResolver = LocalFontFamilyResolver.current
+    val layoutDirection = LocalLayoutDirection.current
+
+    val resolvedStyle = remember(textStyle, layoutDirection) {
+        resolveDefaults(textStyle, layoutDirection)
+    }
+    val typeface by remember(fontFamilyResolver, resolvedStyle) {
+        fontFamilyResolver.resolve(
+            resolvedStyle.fontFamily,
+            resolvedStyle.fontWeight ?: FontWeight.Normal,
+            resolvedStyle.fontStyle ?: FontStyle.Normal,
+            resolvedStyle.fontSynthesis ?: FontSynthesis.All
+        )
+    }
+
+    return remember(density, fontFamilyResolver, textStyle, layoutDirection, typeface) {
+        computeHeightForDefaultText(resolvedStyle, density, fontFamilyResolver, lines)
+    }
+}
+
+fun computeHeightForDefaultText(
+    style: TextStyle,
+    density: Density,
+    fontFamilyResolver: FontFamily.Resolver,
+    lines: Int = 1
+): Int {
+    require(lines >= 0) { "Invalid number of lines: $lines" }
+
+    return computeSizeForDefaultText(
+        style, density, fontFamilyResolver,
+        text = Array(lines) { EmptyTextReplacement }.joinToString("\n"),
+        maxLines = lines
+    ).height
+}
+
+private fun computeSizeForDefaultText(
+    style: TextStyle,
+    density: Density,
+    fontFamilyResolver: FontFamily.Resolver,
+    text: String = EmptyTextReplacement,
+    maxLines: Int = 1
+): IntSize {
+    val paragraph = Paragraph(
+        text = text,
+        style = style,
+        spanStyles = listOf(),
+        maxLines = maxLines,
+        ellipsis = false,
+        density = density,
+        fontFamilyResolver = fontFamilyResolver,
+        constraints = Constraints()
+    )
+    return IntSize(paragraph.minIntrinsicWidth.toIntPx(), paragraph.height.toIntPx())
+}
+
+private fun Float.toIntPx(): Int = ceil(this).roundToInt()

--- a/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/Paragraph.kt
+++ b/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/Paragraph.kt
@@ -15,18 +15,24 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.resolveDefaults
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
 private const val EmptyTextReplacement = "HHHHHHHHHH"
 
+/**
+ * Return the height of a block of text in Dp
+ */
 @Composable
 fun computeHeightForDefaultText(
     textStyle: TextStyle,
     lines: Int = 1
-): Int {
+): Dp {
     require(lines >= 0) { "Invalid number of lines: $lines" }
+    if (lines == 0) return 0.dp
 
     val density = LocalDensity.current
     val fontFamilyResolver = LocalFontFamilyResolver.current
@@ -49,19 +55,21 @@ fun computeHeightForDefaultText(
     }
 }
 
-fun computeHeightForDefaultText(
+private fun computeHeightForDefaultText(
     style: TextStyle,
     density: Density,
     fontFamilyResolver: FontFamily.Resolver,
     lines: Int = 1
-): Int {
-    require(lines >= 0) { "Invalid number of lines: $lines" }
+): Dp {
+    require(lines >= 1) { "Invalid number of lines: $lines" }
 
-    return computeSizeForDefaultText(
-        style, density, fontFamilyResolver,
-        text = Array(lines) { EmptyTextReplacement }.joinToString("\n"),
-        maxLines = lines
-    ).height
+    return with(density) {
+        computeSizeForDefaultText(
+            style, density, fontFamilyResolver,
+            text = Array(lines) { EmptyTextReplacement }.joinToString("\n"),
+            maxLines = lines
+        ).height.toDp()
+    }
 }
 
 private fun computeSizeForDefaultText(
@@ -71,6 +79,8 @@ private fun computeSizeForDefaultText(
     text: String = EmptyTextReplacement,
     maxLines: Int = 1
 ): IntSize {
+    require(maxLines >= 1) { "Invalid number of lines: $maxLines" }
+
     val paragraph = Paragraph(
         text = text,
         style = style,

--- a/gto-support-androidx-compose/src/testDebug/kotlin/org/ccci/gto/android/common/androidx/compose/foundation/text/MinLinesHeightModifierTest.kt
+++ b/gto-support-androidx-compose/src/testDebug/kotlin/org/ccci/gto/android/common/androidx/compose/foundation/text/MinLinesHeightModifierTest.kt
@@ -1,0 +1,46 @@
+package org.ccci.gto.android.common.androidx.compose.foundation.text
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MinLinesHeightModifierTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val textStyle = TextStyle(lineHeight = 14.sp)
+
+    @Test
+    fun `minLinesHeight() - 0 lines`() {
+        composeTestRule.setContent {
+            Spacer(modifier = Modifier.minLinesHeight(0, textStyle))
+        }
+        composeTestRule.onRoot().assertHeightIsEqualTo(0.dp)
+    }
+
+    @Test
+    fun `minLinesHeight() - 1 line`() {
+        composeTestRule.setContent {
+            Spacer(modifier = Modifier.minLinesHeight(1, textStyle))
+        }
+        composeTestRule.onRoot().assertHeightIsEqualTo(35.dp)
+    }
+
+    @Test
+    fun `minLinesHeight() - 2 lines`() {
+        composeTestRule.setContent {
+            Spacer(modifier = Modifier.minLinesHeight(2, textStyle))
+        }
+        composeTestRule.onRoot().assertHeightIsEqualTo(49.dp)
+    }
+}

--- a/gto-support-androidx-compose/src/testDebug/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/ParagraphTest.kt
+++ b/gto-support-androidx-compose/src/testDebug/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/ParagraphTest.kt
@@ -1,0 +1,28 @@
+package org.ccci.gto.android.common.androidx.compose.ui.text
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ParagraphTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val textStyle = TextStyle(lineHeight = 14.sp)
+
+    @Test
+    fun `computeHeightForDefaultText()`() {
+        composeTestRule.setContent {
+            assertEquals(0.dp, computeHeightForDefaultText(textStyle, 0))
+            assertEquals(35.dp, computeHeightForDefaultText(textStyle, 1))
+            assertEquals(49.dp, computeHeightForDefaultText(textStyle, 2))
+        }
+    }
+}


### PR DESCRIPTION
- add a unit test for the minLinesHeight Modifier
- refactor logic to support a computeHeightForDefaultText() method
- add unit test for calculating the height of # of lines of text
