### PR TITLE
Upgrade to Android 13

### DIFF
--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -33,7 +33,7 @@ private fun BaseExtension.configureSdk() {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 32
+        targetSdk = 33
     }
 }
 

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -29,7 +29,7 @@ fun Project.configureAndroidTestingLibrary() {
 }
 
 private fun BaseExtension.configureSdk() {
-    compileSdkVersion(32)
+    compileSdkVersion(33)
 
     defaultConfig {
         minSdk = 21

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.12.2
+version=3.13.0
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g

--- a/gto-support-androidx-compose/src/test/resources/robolectric.properties
+++ b/gto-support-androidx-compose/src/test/resources/robolectric.properties
@@ -1,0 +1,1 @@
+sdk=NEWEST_SDK

--- a/gto-support-compat/src/main/kotlin/org/ccci/gto/android/common/compat/os/BundleCompat.kt
+++ b/gto-support-compat/src/main/kotlin/org/ccci/gto/android/common/compat/os/BundleCompat.kt
@@ -1,0 +1,38 @@
+@file:JvmName("BundleCompat")
+
+package org.ccci.gto.android.common.compat.os
+
+import android.annotation.TargetApi
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
+
+private val COMPAT = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> TiramisuBundleCompatMethods()
+    else -> BaseBundleCompatMethods()
+}
+
+@JvmName("getParcelableArray")
+fun <T : Parcelable> Bundle.getParcelableArrayCompat(key: String?, clazz: Class<T>) =
+    COMPAT.getParcelableArray(this, key, clazz)
+
+private sealed interface BundleCompatMethods {
+    fun <T : Parcelable> getParcelableArray(bundle: Bundle, key: String?, clazz: Class<T>): Array<T?>?
+}
+
+private open class BaseBundleCompatMethods : BundleCompatMethods {
+    override fun <T : Parcelable> getParcelableArray(bundle: Bundle, key: String?, clazz: Class<T>): Array<T?>? {
+        @Suppress("DEPRECATION")
+        val raw = bundle.getParcelableArray(key) ?: return null
+        @Suppress("UNCHECKED_CAST")
+        val arr = java.lang.reflect.Array.newInstance(clazz, raw.size) as Array<T?>
+        System.arraycopy(raw, 0, arr, 0, raw.size)
+        return arr
+    }
+}
+
+@TargetApi(Build.VERSION_CODES.TIRAMISU)
+private class TiramisuBundleCompatMethods : BaseBundleCompatMethods() {
+    override fun <T : Parcelable> getParcelableArray(bundle: Bundle, key: String?, clazz: Class<T>): Array<T?>? =
+        bundle.getParcelableArray(key, clazz)
+}

--- a/gto-support-compat/src/test/kotlin/org/ccci/gto/android/common/compat/os/BundleCompatTest.kt
+++ b/gto-support-compat/src/test/kotlin/org/ccci/gto/android/common/compat/os/BundleCompatTest.kt
@@ -1,6 +1,7 @@
-package org.ccci.gto.android.common.util.os
+package org.ccci.gto.android.common.compat.os
 
 import android.graphics.Point
+import android.os.Build
 import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertArrayEquals
@@ -8,25 +9,27 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Config.NEWEST_SDK
+import org.robolectric.annotation.Config.OLDEST_SDK
 
 private const val KEY1 = "key1"
 private const val KEY2 = "key2"
 
 @RunWith(AndroidJUnit4::class)
-class BundleTest {
-    // region ParcelableArrays
+@Config(sdk = [OLDEST_SDK, Build.VERSION_CODES.S_V2/*, Build.VERSION_CODES.TIRAMISU*/, NEWEST_SDK])
+class BundleCompatTest {
     @Test
-    fun verifyGetParcelableArrayReified() {
+    fun verifyGetParcelableArray() {
         val points = arrayOf(Point(0, 0), null, Point(1, 1))
         val bundle = Bundle().apply {
             putParcelableArray(KEY1, points)
             putParcelableArray(KEY2, null)
         }
 
-        val resp = bundle.getTypedParcelableArray<Point>(KEY1)!!
+        val resp = bundle.getParcelableArrayCompat(KEY1, Point::class.java)!!
         assertEquals(points.javaClass, resp.javaClass)
         assertArrayEquals(points, resp)
-        assertNull(bundle.getTypedParcelableArray<Point>(KEY2))
+        assertNull(bundle.getParcelableArrayCompat(KEY2, Point::class.java))
     }
-    // endregion ParcelableArrays
 }

--- a/gto-support-lottie/src/test/resources/robolectric.properties
+++ b/gto-support-lottie/src/test/resources/robolectric.properties
@@ -1,0 +1,1 @@
+sdk=NEWEST_SDK

--- a/gto-support-util/src/main/kotlin/org/ccci/gto/android/common/util/os/Bundle.kt
+++ b/gto-support-util/src/main/kotlin/org/ccci/gto/android/common/util/os/Bundle.kt
@@ -5,15 +5,17 @@ package org.ccci.gto.android.common.util.os
 
 import android.os.Bundle
 import android.os.Parcelable
+import org.ccci.gto.android.common.compat.os.getParcelableArrayCompat
 
 // region Parcelables
-@Suppress("UNCHECKED_CAST")
-fun <T : Parcelable> Bundle.getParcelableArray(key: String?, clazz: Class<T>) =
-    getParcelableArray(key)?.let {
-        val arr = java.lang.reflect.Array.newInstance(clazz, it.size) as Array<T?>
-        System.arraycopy(it, 0, arr, 0, it.size)
-        arr
-    }
+@Deprecated(
+    "Since v3.13.0, use Bundle.getParcelableArrayCompat(key, clazz) instead.",
+    ReplaceWith(
+        "getParcelableArrayCompat(key, clazz)",
+        "org.ccci.gto.android.common.compat.os.getParcelableArrayCompat"
+    )
+)
+fun <T : Parcelable> Bundle.getParcelableArray(key: String?, clazz: Class<T>) = getParcelableArrayCompat(key, clazz)
 
 inline fun <reified T : Parcelable> Bundle.getTypedParcelableArray(key: String?) =
     getParcelableArray(key)?.let { it: Array<Parcelable?> ->


### PR DESCRIPTION
- compile against API level 33
- create getParcelableArrayCompat method to provide fallback behavior for new API added in Android 13
- target the latest version of Android
