### PR TITLE
utilize remember to avoid re-linkifying a string on recomposition

### DIFF
--- a/gto-support-androidx-compose-material3/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/material3/ui/text/AnnotatedString+Linkify.kt
+++ b/gto-support-androidx-compose-material3/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/material3/ui/text/AnnotatedString+Linkify.kt
@@ -2,6 +2,7 @@ package org.ccci.gto.android.common.androidx.compose.material3.ui.text
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.style.TextDecoration
@@ -14,10 +15,16 @@ private val DefaultLinkStyle @Composable get() = SpanStyle(
 )
 
 @Composable
-fun String.addUriAnnotations(@LinkifyMask mask: Int) = addUriAnnotations(mask, DefaultLinkStyle)
+fun String.addUriAnnotations(@LinkifyMask mask: Int): AnnotatedString {
+    val style = DefaultLinkStyle
+    return remember(this, mask, style) { addUriAnnotations(mask, style) }
+}
 
 @Composable
-fun AnnotatedString.addUriAnnotations(@LinkifyMask mask: Int) = addUriAnnotations(mask, DefaultLinkStyle)
+fun AnnotatedString.addUriAnnotations(@LinkifyMask mask: Int): AnnotatedString {
+    val style = DefaultLinkStyle
+    return remember(this, mask, style) { addUriAnnotations(mask, style) }
+}
 
 @Composable
 private fun AnnotatedString.Builder.addUriAnnotations(@LinkifyMask mask: Int) =


### PR DESCRIPTION
This is a performance improvement that avoids needing to run the expensive Linkify logic every time the Text element is recomposed.