### PR TITLE
cleanup

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,4 +1,3 @@
-enableFeaturePreview("VERSION_CATALOGS")
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {

--- a/gto-support-androidx-compose-material3/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/material3/ClickableText.kt
+++ b/gto-support-androidx-compose-material3/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/material3/ClickableText.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
@@ -27,13 +29,9 @@ fun ClickableText(
     onClick: (Int) -> Unit
 ) {
     // logic copied from the compose-foundation ClickableText
-    val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
     val pressIndicator = Modifier.pointerInput(onClick) {
-        detectTapGestures { pos ->
-            layoutResult.value?.let { layoutResult ->
-                onClick(layoutResult.getOffsetForPosition(pos))
-            }
-        }
+        detectTapGestures { layoutResult?.getOffsetForPosition(it)?.let { onClick(it) } }
     }
 
     Text(
@@ -43,7 +41,7 @@ fun ClickableText(
         overflow = overflow,
         maxLines = maxLines,
         onTextLayout = {
-            layoutResult.value = it
+            layoutResult = it
             onTextLayout(it)
         },
         style = style,

--- a/gto-support-androidx-compose-material3/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/material3/ClickableText.kt
+++ b/gto-support-androidx-compose-material3/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/material3/ClickableText.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 
 // NOTE: this is hopefully temporary until a ClickableText composable is added to Material3
@@ -22,6 +23,7 @@ fun ClickableText(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    fontFamily: FontFamily? = null,
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,
     onTextLayout: (TextLayoutResult) -> Unit = {},
@@ -38,6 +40,7 @@ fun ClickableText(
         text = text,
         modifier = modifier.then(pressIndicator),
         color = color,
+        fontFamily = fontFamily,
         overflow = overflow,
         maxLines = maxLines,
         onTextLayout = {

--- a/gto-support-compat/src/main/java/org/ccci/gto/android/common/compat/view/TextViewCompat.java
+++ b/gto-support-compat/src/main/java/org/ccci/gto/android/common/compat/view/TextViewCompat.java
@@ -5,6 +5,10 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+/**
+ * @deprecated Since v3.10.0, all methods have been deprecated.
+ */
+@Deprecated
 public class TextViewCompat {
     /**
      * @deprecated Since v3.10.0, use


### PR DESCRIPTION
- TextViewCompat should be marked as deprecated as well
- VERSION_CATALOGS is stable and no longer needs to be enabled as a feature preview
- condense some logic, no functional changes
- allow specifying a fontFamily for ClickableText
