### PR TITLE
Prevent an empty string being used as the name of the SessionInterceptor preference file

### DIFF
--- a/gto-support-api-okhttp3/src/main/java/org/ccci/gto/android/common/api/okhttp3/interceptor/SessionInterceptor.kt
+++ b/gto-support-api-okhttp3/src/main/java/org/ccci/gto/android/common/api/okhttp3/interceptor/SessionInterceptor.kt
@@ -3,6 +3,7 @@ package org.ccci.gto.android.common.api.okhttp3.interceptor
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.CallSuper
+import androidx.annotation.VisibleForTesting
 import java.io.IOException
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
@@ -20,9 +21,13 @@ abstract class SessionInterceptor<S : Session> @JvmOverloads protected construct
     prefFile: String? = null
 ) : Interceptor {
     protected val context: Context = context.applicationContext
-    protected val prefs by lazy {
-        this.context.getSharedPreferences(prefFile ?: javaClass.simpleName, Context.MODE_PRIVATE)
-    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val prefFileName = prefFile?.also { require(it.isNotEmpty()) { "prefFile cannot be an empty string" } }
+        ?: generateSequence<Class<*>>(javaClass) { it.superclass }
+            .mapNotNull { it.simpleName.takeUnless { it.isEmpty() } }
+            .first()
+    protected val prefs by lazy { this.context.getSharedPreferences(prefFileName, Context.MODE_PRIVATE) }
 
     protected val lockSession = Any()
 

--- a/gto-support-api-okhttp3/src/test/kotlin/org/ccci/gto/android/common/api/okhttp3/interceptor/SessionInterceptorTest.kt
+++ b/gto-support-api-okhttp3/src/test/kotlin/org/ccci/gto/android/common/api/okhttp3/interceptor/SessionInterceptorTest.kt
@@ -17,6 +17,7 @@ import okhttp3.Response
 import org.ccci.gto.android.common.api.Session
 import org.ccci.gto.android.common.api.okhttp3.EstablishSessionApiException
 import org.ccci.gto.android.common.api.okhttp3.InvalidSessionApiException
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
@@ -33,6 +34,39 @@ class SessionInterceptorTest {
         excludeRecords { isValid }
     }
     private val invalidSession = spyk(MockSession(null))
+
+    // region prefFileName
+    @Test
+    fun verifyPrefFileName() {
+        val interceptor = object : SessionInterceptor<MockSession>(context, prefFile = "test") {
+            override fun loadSession(prefs: SharedPreferences) = null
+            override fun attachSession(request: Request, session: MockSession) = request
+        }
+        assertEquals("test", interceptor.prefFileName)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `verifyPrefFileName - invalid name`() {
+        object : SessionInterceptor<MockSession>(context, prefFile = "") {
+            override fun loadSession(prefs: SharedPreferences) = null
+            override fun attachSession(request: Request, session: MockSession) = request
+        }
+    }
+
+    @Test
+    fun `verifyPrefFileName - default value`() {
+        assertEquals("MockSessionInterceptor", MockSessionInterceptor(context).prefFileName)
+    }
+
+    @Test
+    fun `verifyPrefFileName - default value - anonymous class`() {
+        val interceptor = object : SessionInterceptor<MockSession>(context) {
+            override fun loadSession(prefs: SharedPreferences) = null
+            override fun attachSession(request: Request, session: MockSession) = request
+        }
+        assertEquals("SessionInterceptor", interceptor.prefFileName)
+    }
+    // endregion prefFileName
 
     @Test
     fun `Existing session is valid`() {

--- a/gto-support-api-okhttp3/src/test/kotlin/org/ccci/gto/android/common/api/okhttp3/interceptor/SessionInterceptorTest.kt
+++ b/gto-support-api-okhttp3/src/test/kotlin/org/ccci/gto/android/common/api/okhttp3/interceptor/SessionInterceptorTest.kt
@@ -2,6 +2,13 @@ package org.ccci.gto.android.common.api.okhttp3.interceptor
 
 import android.content.Context
 import android.content.SharedPreferences
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.excludeRecords
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifyAll
 import java.io.IOException
 import java.util.concurrent.Callable
 import okhttp3.Interceptor
@@ -11,115 +18,97 @@ import org.ccci.gto.android.common.api.Session
 import org.ccci.gto.android.common.api.okhttp3.EstablishSessionApiException
 import org.ccci.gto.android.common.api.okhttp3.InvalidSessionApiException
 import org.junit.Assert.assertThrows
-import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.RETURNS_DEEP_STUBS
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.doThrow
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.spy
-import org.mockito.kotlin.stub
-import org.mockito.kotlin.verify
 
 class SessionInterceptorTest {
-    private lateinit var response: Response
-    private lateinit var chain: Interceptor.Chain
-    private lateinit var context: Context
-    private lateinit var sessionInterceptor: MockSessionInterceptor
-
-    private val validSession = spy(MockSession("valid"))
-    private val invalidSession = spy(MockSession(null))
-
-    @Before
-    fun setup() {
-        response = mock()
-        chain = mock {
-            on { request() } doReturn Request.Builder().url("https://example.com").build()
-            on { proceed(any()) } doReturn response
-        }
-        context = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-        sessionInterceptor = MockSessionInterceptor(context)
+    private val response: Response = mockk()
+    private val chain: Interceptor.Chain = mockk {
+        every { request() } returns Request.Builder().url("https://example.com").build()
+        every { proceed(any()) } returns response
     }
+    private val context: Context = mockk(relaxed = true)
+    private val sessionInterceptor = MockSessionInterceptor(context)
+
+    private val validSession = spyk(MockSession("valid")) {
+        excludeRecords { isValid }
+    }
+    private val invalidSession = spyk(MockSession(null))
 
     @Test
     fun `Existing session is valid`() {
-        sessionInterceptor.stub {
-            on { loadSession(any()) } doReturn validSession
-        }
+        every { sessionInterceptor.loadSession(any()) } returns validSession
 
         sessionInterceptor.intercept(chain)
-        verify(sessionInterceptor.establishSession, never()).call()
-        verify(sessionInterceptor.attachSession).invoke(any(), any())
-        verify(validSession, never()).save(any())
+        verifyAll {
+            sessionInterceptor.establishSession wasNot Called
+            sessionInterceptor.attachSession(any(), any())
+        }
+        verify(exactly = 0) { validSession.save(any()) }
     }
 
     @Test
     fun `Existing session is invalid - establishSession() returns valid session`() {
-        sessionInterceptor.stub {
-            on { loadSession(any()) } doReturn invalidSession
-            on { establishSession() } doReturn validSession
-        }
+        every { sessionInterceptor.loadSession(any()) } returns invalidSession
+        every { sessionInterceptor.establishSession() } returns validSession
 
         sessionInterceptor.intercept(chain)
-        verify(sessionInterceptor.establishSession).call()
-        verify(sessionInterceptor.attachSession).invoke(any(), eq(validSession))
-        verify(validSession).save(any())
-        verify(invalidSession, never()).save(any())
+        verifyAll {
+            sessionInterceptor.establishSession.call()
+            sessionInterceptor.attachSession(any(), validSession)
+            validSession.save(any())
+        }
+        verify(exactly = 0) { invalidSession.save(any()) }
     }
 
     @Test
     fun `Existing session is invalid - establishSession() returns null`() {
-        sessionInterceptor.stub {
-            on { loadSession(any()) } doReturn invalidSession
-            on { establishSession() } doReturn null
-        }
+        every { sessionInterceptor.loadSession(any()) } returns invalidSession
+        every { sessionInterceptor.establishSession() } returns null
 
         assertThrows(InvalidSessionApiException::class.java) {
             sessionInterceptor.intercept(chain)
         }
-        verify(sessionInterceptor.establishSession).call()
-        verify(sessionInterceptor.attachSession, never()).invoke(any(), any())
-        verify(invalidSession, never()).save(any())
+        verifyAll {
+            sessionInterceptor.establishSession.call()
+            sessionInterceptor.attachSession wasNot Called
+        }
+        verify(exactly = 0) { invalidSession.save(any()) }
     }
 
     @Test
     fun `Existing session is invalid - establishSession() throws IOException`() {
-        sessionInterceptor.stub {
-            on { loadSession(any()) } doReturn invalidSession
-            on { establishSession() } doThrow IOException::class
-        }
+        every { sessionInterceptor.loadSession(any()) } returns invalidSession
+        every { sessionInterceptor.establishSession() } throws IOException()
 
         assertThrows(EstablishSessionApiException::class.java) {
             sessionInterceptor.intercept(chain)
         }
-        verify(sessionInterceptor.establishSession).call()
-        verify(sessionInterceptor.attachSession, never()).invoke(any(), any())
-        verify(invalidSession, never()).save(any())
+        verifyAll {
+            sessionInterceptor.establishSession.call()
+            sessionInterceptor.attachSession wasNot Called
+        }
+        verify(exactly = 0) { invalidSession.save(any()) }
     }
 
     @Test
     fun `Existing session is null - establishSession() returns valid session`() {
-        sessionInterceptor.stub {
-            on { loadSession(any()) } doReturn null
-            on { establishSession() } doReturn validSession
-        }
+        every { sessionInterceptor.loadSession(any()) } returns null
+        every { sessionInterceptor.establishSession() } returns validSession
 
         sessionInterceptor.intercept(chain)
-        verify(sessionInterceptor.establishSession).call()
-        verify(sessionInterceptor.attachSession).invoke(any(), eq(validSession))
-        verify(validSession).save(any())
+        verifyAll {
+            sessionInterceptor.establishSession.call()
+            sessionInterceptor.attachSession(any(), validSession)
+            validSession.save(any())
+        }
     }
 
     private class MockSession(id: String?) : Session(id)
     private class MockSessionInterceptor(context: Context) : SessionInterceptor<MockSession>(context) {
-        val loadSession = mock<(SharedPreferences) -> MockSession?>()
-        val establishSession = mock<Callable<MockSession?>>()
-        val attachSession = mock<(Request, MockSession) -> Request> {
-            on { invoke(any(), any()) } doAnswer { it.getArgument(0) }
+        val loadSession = mockk<(SharedPreferences) -> MockSession?>()
+        val establishSession = mockk<Callable<MockSession?>>()
+        val attachSession = mockk<(Request, MockSession) -> Request>().also {
+            every { it(any(), any()) } answers { it.invocation.args[0] as Request }
         }
 
         override fun loadSession(prefs: SharedPreferences) = loadSession.invoke(prefs)


### PR DESCRIPTION
This bug surfaced because I was using an anonymous instance of the SessionInterceptor. Which ended up causing Facebook Flipper to crash the app because it doesn't support preference file names that are empty.

relevant crash: [Crashlytics](https://console.firebase.google.com/u/0/project/godtools-b2f82/crashlytics/app/android:org.keynote.godtools.android.debug/issues/d9497696a68602ebda93a0ff03f3a3c0?time=last-seven-days&sessionEventKey=6348349D0364000123C86E75D7EAC283_1732471467181845713)

Changes:
- update SessionInterceptorTest to utilize MockK instead of Mockito
- Prevent an empty string being used as the name of the SessionInterceptor preference file