### PR TITLE
cleanup

### DIFF
--- a/gto-support-androidx-room/build.gradle.kts
+++ b/gto-support-androidx-room/build.gradle.kts
@@ -6,6 +6,10 @@ plugins {
 android {
     namespace = "org.ccci.gto.android.common.androidx.room"
     baseConfiguration(project)
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {

--- a/gto-support-androidx-room/build.gradle.kts
+++ b/gto-support-androidx-room/build.gradle.kts
@@ -3,7 +3,10 @@ plugins {
     kotlin("android")
 }
 
-configureAndroidLibrary()
+android {
+    namespace = "org.ccci.gto.android.common.androidx.room"
+    baseConfiguration(project)
+}
 
 dependencies {
     implementation(libs.androidx.room.common)

--- a/gto-support-androidx-room/src/main/AndroidManifest.xml
+++ b/gto-support-androidx-room/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.ccci.gto.android.common.androidx.room" />

--- a/gto-support-androidx-room/src/main/kotlin/org/ccci/gto/android/common/androidx/room/converter/Java8TimeConverters.kt
+++ b/gto-support-androidx-room/src/main/kotlin/org/ccci/gto/android/common/androidx/room/converter/Java8TimeConverters.kt
@@ -1,18 +1,14 @@
 package org.ccci.gto.android.common.androidx.room.converter
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.room.TypeConverter
 import java.time.Instant
 
 object Java8TimeConverters {
     @JvmStatic
     @TypeConverter
-    @RequiresApi(Build.VERSION_CODES.O)
     internal fun Long?.toInstant() = this?.let { Instant.ofEpochMilli(it) }
 
     @JvmStatic
     @TypeConverter
-    @RequiresApi(Build.VERSION_CODES.O)
     internal fun Instant?.toLong() = this?.toEpochMilli()
 }

--- a/gto-support-jsonapi/build.gradle.kts
+++ b/gto-support-jsonapi/build.gradle.kts
@@ -3,9 +3,10 @@ plugins {
     kotlin("android")
 }
 
-configureAndroidLibrary()
-
 android {
+    namespace = "org.ccci.gto.android.common.jsonapi"
+    baseConfiguration(project)
+
     defaultConfig.consumerProguardFiles("proguard-consumer.pro")
 }
 

--- a/gto-support-jsonapi/build.gradle.kts
+++ b/gto-support-jsonapi/build.gradle.kts
@@ -7,6 +7,9 @@ android {
     namespace = "org.ccci.gto.android.common.jsonapi"
     baseConfiguration(project)
 
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
     defaultConfig.consumerProguardFiles("proguard-consumer.pro")
 }
 

--- a/gto-support-jsonapi/src/main/AndroidManifest.xml
+++ b/gto-support-jsonapi/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.ccci.gto.android.common.jsonapi"/>

--- a/gto-support-jsonapi/src/main/kotlin/org/ccci/gto/android/common/jsonapi/converter/InstantConverter.kt
+++ b/gto-support-jsonapi/src/main/kotlin/org/ccci/gto/android/common/jsonapi/converter/InstantConverter.kt
@@ -1,11 +1,8 @@
 package org.ccci.gto.android.common.jsonapi.converter
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 
-@RequiresApi(Build.VERSION_CODES.O)
 class InstantConverter(private val formatter: DateTimeFormatter) : TypeConverter<Instant> {
     constructor() : this(DateTimeFormatter.ISO_INSTANT)
 


### PR DESCRIPTION
- configure the namespace of a couple subprojects from their build script
- mark libraries as using core library desugaring instead of requiring a certain SDK level
