### PR TITLE
copy RealmRecyclerViewAdapter into gto-support-realm

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,6 @@ allprojects {
         }
         google()
         mavenCentral()
-        jcenter {
-            content { includeModule("io.realm", "android-adapters") }
-        }
     }
 
     afterEvaluate {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,7 +100,6 @@ okta-auth-foundation-bootstrap = { module = "com.okta.kotlin:auth-foundation-boo
 picasso = { module = "com.squareup.picasso:picasso", version = "2.8" }
 play-core = "com.google.android.play:core:1.10.3"
 realm = "io.realm:realm-android-library:10.12.0"
-realm-adapters = { module = "io.realm:android-adapters", version = "4.0.0" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version = "2.9.0" }
 robolectric = "org.robolectric:robolectric:4.9"
 scarlet = { module = "com.tinder.scarlet:scarlet", version.ref = "scarlet" }

--- a/gto-support-realm/build.gradle.kts
+++ b/gto-support-realm/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     compileOnly(project(":gto-support-recyclerview"))
     compileOnly(libs.androidx.databinding.runtime)
     compileOnly(libs.androidx.lifecycle.livedata.core)
-    compileOnly(libs.realm.adapters)
     implementation(libs.weakdelegate)
     // endregion RecyclerViewAdapter dependencies
 }

--- a/gto-support-realm/src/main/java/io/realm/RealmRecyclerViewAdapter.java
+++ b/gto-support-realm/src/main/java/io/realm/RealmRecyclerViewAdapter.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO: this is duplicated from https://github.com/realm/realm-android-adapters to workaround the legacy jcenter
+//       repository being offline.
+//       If realm-android-adapters is ever published to mavenCentral we can revert to importing this class from there.
+//       see: https://github.com/realm/realm-android-adapters/pull/162
+package io.realm;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * The RealmBaseRecyclerAdapter class is an abstract utility class for binding RecyclerView UI elements to Realm data.
+ * <p>
+ * This adapter will automatically handle any updates to its data and call {@code notifyDataSetChanged()},
+ * {@code notifyItemInserted()}, {@code notifyItemRemoved()} or {@code notifyItemRangeChanged()} as appropriate.
+ * <p>
+ * The RealmAdapter will stop receiving updates if the Realm instance providing the {@link OrderedRealmCollection} is
+ * closed.
+ * <p>
+ * If the adapter contains Realm model classes with a primary key that is either an {@code int} or a {@code long}, call
+ * {@code setHasStableIds(true)} in the constructor and override {@link #getItemId(int)} as described by the Javadoc in
+ * that method.
+ *
+ * @param <T> type of {@link RealmModel} stored in the adapter.
+ * @param <S> type of RecyclerView.ViewHolder used in the adapter.
+ * @see RecyclerView.Adapter#setHasStableIds(boolean)
+ * @see RecyclerView.Adapter#getItemId(int)
+ */
+public abstract class RealmRecyclerViewAdapter<T extends RealmModel, S extends RecyclerView.ViewHolder>
+        extends RecyclerView.Adapter<S> {
+
+    private final boolean hasAutoUpdates;
+    private final boolean updateOnModification;
+    private final OrderedRealmCollectionChangeListener listener;
+    @Nullable
+    private OrderedRealmCollection<T> adapterData;
+
+    private OrderedRealmCollectionChangeListener createListener() {
+        return new OrderedRealmCollectionChangeListener() {
+            @Override
+            public void onChange(Object collection, OrderedCollectionChangeSet changeSet) {
+                if (changeSet.getState() == OrderedCollectionChangeSet.State.INITIAL) {
+                    notifyDataSetChanged();
+                    return;
+                }
+                // For deletions, the adapter has to be notified in reverse order.
+                OrderedCollectionChangeSet.Range[] deletions = changeSet.getDeletionRanges();
+                for (int i = deletions.length - 1; i >= 0; i--) {
+                    OrderedCollectionChangeSet.Range range = deletions[i];
+                    notifyItemRangeRemoved(range.startIndex + dataOffset(), range.length);
+                }
+
+                OrderedCollectionChangeSet.Range[] insertions = changeSet.getInsertionRanges();
+                for (OrderedCollectionChangeSet.Range range : insertions) {
+                    notifyItemRangeInserted(range.startIndex + dataOffset(), range.length);
+                }
+
+                if (!updateOnModification) {
+                    return;
+                }
+
+                OrderedCollectionChangeSet.Range[] modifications = changeSet.getChangeRanges();
+                for (OrderedCollectionChangeSet.Range range : modifications) {
+                    notifyItemRangeChanged(range.startIndex + dataOffset(), range.length);
+                }
+            }
+        };
+    }
+
+    /**
+     * Returns the number of header elements before the Realm collection elements. This is needed so
+     * all indexes reported by the {@link OrderedRealmCollectionChangeListener} can be adjusted
+     * correctly. Failing to override can cause the wrong elements to animate and lead to runtime
+     * exceptions.
+     *
+     * @return The number of header elements in the RecyclerView before the collection elements. Default is {@code 0}.
+     */
+    public int dataOffset() {
+        return 0;
+    }
+
+    /**
+     * This is equivalent to {@code RealmRecyclerViewAdapter(data, autoUpdate, true)}.
+     *
+     * @param data collection data to be used by this adapter.
+     * @param autoUpdate when it is {@code false}, the adapter won't be automatically updated when collection data
+     *                   changes.
+     * @see #RealmRecyclerViewAdapter(OrderedRealmCollection, boolean, boolean)
+     */
+    public RealmRecyclerViewAdapter(@Nullable OrderedRealmCollection<T> data, boolean autoUpdate) {
+        this(data, autoUpdate, true);
+    }
+
+    /**
+     * @param data collection data to be used by this adapter.
+     * @param autoUpdate when it is {@code false}, the adapter won't be automatically updated when collection data
+     *                   changes.
+     * @param updateOnModification when it is {@code true}, this adapter will be updated when deletions, insertions or
+     *                             modifications happen to the collection data. When it is {@code false}, only
+     *                             deletions and insertions will trigger the updates. This param will be ignored if
+     *                             {@code autoUpdate} is {@code false}.
+     */
+    public RealmRecyclerViewAdapter(@Nullable OrderedRealmCollection<T> data, boolean autoUpdate,
+                                    boolean updateOnModification) {
+        if (data != null && !data.isManaged())
+            throw new IllegalStateException("Only use this adapter with managed RealmCollection, " +
+                    "for un-managed lists you can just use the BaseRecyclerViewAdapter");
+        this.adapterData = data;
+        this.hasAutoUpdates = autoUpdate;
+        this.listener = hasAutoUpdates ? createListener() : null;
+        this.updateOnModification = updateOnModification;
+    }
+
+    @Override
+    public void onAttachedToRecyclerView(final RecyclerView recyclerView) {
+        super.onAttachedToRecyclerView(recyclerView);
+        if (hasAutoUpdates && isDataValid()) {
+            //noinspection ConstantConditions
+            addListener(adapterData);
+        }
+    }
+
+    @Override
+    public void onDetachedFromRecyclerView(final RecyclerView recyclerView) {
+        super.onDetachedFromRecyclerView(recyclerView);
+        if (hasAutoUpdates && isDataValid()) {
+            //noinspection ConstantConditions
+            removeListener(adapterData);
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        //noinspection ConstantConditions
+        return isDataValid() ? adapterData.size() : 0;
+    }
+
+    /**
+     * Returns the item in the underlying data associated with the specified position.
+     *
+     * This method will return {@code null} if the Realm instance has been closed or the index
+     * is outside the range of valid adapter data (which e.g. can happen if {@link #getItemCount()}
+     * is modified to account for header or footer views.
+     *
+     * Also, this method does not take into account any header views. If these are present, modify
+     * the {@code index} parameter accordingly first.
+     *
+     * @param index index of the item in the original collection backing this adapter.
+     * @return the item at the specified position or {@code null} if the position does not exists or
+     * the adapter data are no longer valid.
+     */
+    @SuppressWarnings("WeakerAccess")
+    @Nullable
+    public T getItem(int index) {
+        if (index < 0) {
+            throw new IllegalArgumentException("Only indexes >= 0 are allowed. Input was: " + index);
+        }
+
+        // To avoid exception, return null if there are some extra positions that the
+        // child adapter is adding in getItemCount (e.g: to display footer view in recycler view)
+        if (adapterData != null && index >= adapterData.size()) return null;
+        //noinspection ConstantConditions
+        return isDataValid() ? adapterData.get(index) : null;
+    }
+
+    /**
+     * Returns data associated with this adapter.
+     *
+     * @return adapter data.
+     */
+    @Nullable
+    public OrderedRealmCollection<T> getData() {
+        return adapterData;
+    }
+
+    /**
+     * Updates the data associated to the Adapter. Useful when the query has been changed.
+     * If the query does not change you might consider using the automaticUpdate feature.
+     *
+     * @param data the new {@link OrderedRealmCollection} to display.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public void updateData(@Nullable OrderedRealmCollection<T> data) {
+        if (hasAutoUpdates) {
+            if (isDataValid()) {
+                //noinspection ConstantConditions
+                removeListener(adapterData);
+            }
+            if (data != null) {
+                addListener(data);
+            }
+        }
+
+        this.adapterData = data;
+        notifyDataSetChanged();
+    }
+
+    private void addListener(@NonNull OrderedRealmCollection<T> data) {
+        if (data instanceof RealmResults) {
+            RealmResults<T> results = (RealmResults<T>) data;
+            //noinspection unchecked
+            results.addChangeListener(listener);
+        } else if (data instanceof RealmList) {
+            RealmList<T> list = (RealmList<T>) data;
+            //noinspection unchecked
+            list.addChangeListener(listener);
+        } else {
+            throw new IllegalArgumentException("RealmCollection not supported: " + data.getClass());
+        }
+    }
+
+    private void removeListener(@NonNull OrderedRealmCollection<T> data) {
+        if (data instanceof RealmResults) {
+            RealmResults<T> results = (RealmResults<T>) data;
+            //noinspection unchecked
+            results.removeChangeListener(listener);
+        } else if (data instanceof RealmList) {
+            RealmList<T> list = (RealmList<T>) data;
+            //noinspection unchecked
+            list.removeChangeListener(listener);
+        } else {
+            throw new IllegalArgumentException("RealmCollection not supported: " + data.getClass());
+        }
+    }
+
+    private boolean isDataValid() {
+        return adapterData != null && adapterData.isValid();
+    }
+}


### PR DESCRIPTION
The library we are copying this from was only available via jcenter, which is currently offline.
This is meant to be temporary until the realm-android-adapters library is released on mavenCentral.
see: https://github.com/realm/realm-android-adapters/pull/162
