### PR TITLE
Support a couple AndroidX testing annotations on multiplatform projects

### DIFF
--- a/gto-support-androidx-annotation/build.gradle.kts
+++ b/gto-support-androidx-annotation/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+    alias(libs.plugins.kotlin.kover)
+}
+
+android {
+    namespace = "org.ccci.gto.support.androidx.annotation"
+    baseConfiguration(project)
+}
+
+kotlin {
+    baseConfiguration()
+    configureTargets(project)
+
+    sourceSets {
+        val androidMain by getting {
+            dependencies {
+                api(libs.androidx.annotation)
+            }
+        }
+    }
+}

--- a/gto-support-androidx-annotation/src/androidMain/kotlin/org/ccci/gto/support/androidx/annotation/RestrictTo.android.kt
+++ b/gto-support-androidx-annotation/src/androidMain/kotlin/org/ccci/gto/support/androidx/annotation/RestrictTo.android.kt
@@ -1,0 +1,4 @@
+package org.ccci.gto.support.androidx.annotation
+
+actual typealias RestrictTo = androidx.annotation.RestrictTo
+actual typealias RestrictToScope = androidx.annotation.RestrictTo.Scope

--- a/gto-support-androidx-annotation/src/androidMain/kotlin/org/ccci/gto/support/androidx/annotation/VisibleForTesting.android.kt
+++ b/gto-support-androidx-annotation/src/androidMain/kotlin/org/ccci/gto/support/androidx/annotation/VisibleForTesting.android.kt
@@ -1,0 +1,3 @@
+package org.ccci.gto.support.androidx.annotation
+
+actual typealias VisibleForTesting = androidx.annotation.VisibleForTesting

--- a/gto-support-androidx-annotation/src/commonMain/kotlin/org/ccci/gto/support/androidx/annotation/RestrictTo.kt
+++ b/gto-support-androidx-annotation/src/commonMain/kotlin/org/ccci/gto/support/androidx/annotation/RestrictTo.kt
@@ -1,0 +1,7 @@
+package org.ccci.gto.support.androidx.annotation
+
+@OptIn(ExperimentalMultiplatform::class)
+@OptionalExpectation
+@Target(AnnotationTarget.CONSTRUCTOR, AnnotationTarget.PROPERTY_GETTER)
+expect annotation class RestrictTo(vararg val value: RestrictToScope)
+expect enum class RestrictToScope { TESTS, SUBCLASSES }

--- a/gto-support-androidx-annotation/src/commonMain/kotlin/org/ccci/gto/support/androidx/annotation/VisibleForTesting.kt
+++ b/gto-support-androidx-annotation/src/commonMain/kotlin/org/ccci/gto/support/androidx/annotation/VisibleForTesting.kt
@@ -1,0 +1,6 @@
+package org.ccci.gto.support.androidx.annotation
+
+@OptIn(ExperimentalMultiplatform::class)
+@OptionalExpectation
+@Retention(AnnotationRetention.BINARY)
+expect annotation class VisibleForTesting()

--- a/gto-support-androidx-annotation/src/iosMain/kotlin/org/ccci/gto/support/androidx/annotation/RestrictToScope.ios.kt
+++ b/gto-support-androidx-annotation/src/iosMain/kotlin/org/ccci/gto/support/androidx/annotation/RestrictToScope.ios.kt
@@ -1,0 +1,3 @@
+package org.ccci.gto.support.androidx.annotation
+
+actual enum class RestrictToScope { TESTS, SUBCLASSES }

--- a/gto-support-androidx-annotation/src/jsMain/kotlin/org/ccci/gto/support/androidx/annotation/RestrictToScope.js.kt
+++ b/gto-support-androidx-annotation/src/jsMain/kotlin/org/ccci/gto/support/androidx/annotation/RestrictToScope.js.kt
@@ -1,0 +1,3 @@
+package org.ccci.gto.support.androidx.annotation
+
+actual enum class RestrictToScope { TESTS, SUBCLASSES }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ if (System.getenv("GITHUB_ACTIONS")?.toBoolean() == true) {
     }
 }
 
+include("gto-support-androidx-annotation")
 include("gto-support-androidx-collection")
 include("gto-support-androidx-compose")
 include("gto-support-androidx-compose-material3")


### PR DESCRIPTION
- create a new androidx-annotation multiplatform library
- add mutliplatform definition for VisibleForTesting
- add multiplatform expect for RestrictTo annotation
