### PR TITLE
create a RoomDatabaseRule to aid with Room DB testing

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,14 @@
 [versions]
 accompanist = "0.28.0"
 android-gradle-plugin = "7.3.1"
+androidx-arch-core = "2.1.0"
 androidx-collection = "1.2.0"
 androidx-compose = "1.3.1"
 androidx-compose-compiler = "1.4.0-alpha02"
 androidx-core = "1.9.0"
 androidx-fragment = "1.5.5"
 androidx-lifecycle = "2.5.1"
+androidx-room = "2.4.3"
 checkstyle = "7.8.2"
 dagger = "2.44.2"
 hamcrest = "2.2"
@@ -24,7 +26,8 @@ advancedrecyclerview = { module = "com.h6ah4i.android.widget.advrecyclerview:adv
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 androidx-annotation = "androidx.annotation:annotation:1.5.0"
 androidx-appcompat = "androidx.appcompat:appcompat:1.5.1"
-androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version = "2.1.0" }
+androidx-arch-core-runtime = { module = "androidx.arch.core:core-runtime", version.ref = "androidx-arch-core" }
+androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-core" }
 androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
 androidx-collection-ktx = { module = "androidx.collection:collection-ktx", version.ref = "androidx-collection" }
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "androidx-compose" }
@@ -53,10 +56,12 @@ androidx-lifecycle-runtime-testing = { module = "androidx.lifecycle:lifecycle-ru
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-savedstate = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version = "1.2.1" }
-androidx-room-common = "androidx.room:room-common:2.4.3"
+androidx-room-common = { module = "androidx.room:room-common", version.ref = "androidx-room" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
 androidx-security-crypto = "androidx.security:security-crypto:1.0.0"
 androidx-sqlite = "androidx.sqlite:sqlite:2.2.0"
 androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version = "1.1.0" }
+androidx-test = "androidx.test:core:1.5.0"
 androidx-test-junit = { module = "androidx.test.ext:junit", version = "1.1.4" }
 androidx-viewpager = { module = "androidx.viewpager:viewpager", version = "1.0.0" }
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version = "1.0.0" }

--- a/gto-support-androidx-room/build.gradle.kts
+++ b/gto-support-androidx-room/build.gradle.kts
@@ -7,11 +7,16 @@ android {
     namespace = "org.ccci.gto.android.common.androidx.room"
     baseConfiguration(project)
 
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-    }
+    compileOptions.isCoreLibraryDesugaringEnabled = true
+    testFixtures.enable = true
 }
 
 dependencies {
     implementation(libs.androidx.room.common)
+
+    testFixturesApi(libs.androidx.room.runtime)
+    testFixturesApi(libs.junit)
+    testFixturesImplementation(libs.androidx.arch.core.runtime)
+    testFixturesImplementation(libs.androidx.test)
+    testFixturesCompileOnly(libs.kotlin.coroutines)
 }

--- a/gto-support-androidx-room/src/testFixtures/java/org/ccci/gto/android/common/androidx/room/RoomDatabaseRule.java
+++ b/gto-support-androidx-room/src/testFixtures/java/org/ccci/gto/android/common/androidx/room/RoomDatabaseRule.java
@@ -1,0 +1,63 @@
+package org.ccci.gto.android.common.androidx.room;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.arch.core.executor.ArchTaskExecutor;
+import androidx.room.Room;
+import androidx.room.RoomDatabase;
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.util.concurrent.Executor;
+
+import kotlinx.coroutines.CoroutineDispatcher;
+import kotlinx.coroutines.ExecutorsKt;
+
+// TODO: convert this to Kotlin once Android Test Fixtures support Kotlin
+//       https://youtrack.jetbrains.com/issue/KT-50667
+//       https://issuetracker.google.com/issues/259523353
+public class RoomDatabaseRule<T extends RoomDatabase> extends TestWatcher {
+    public RoomDatabaseRule(@NonNull Class<T> dbClass) {
+        this(dbClass, (Executor) null);
+    }
+
+    public RoomDatabaseRule(@NonNull Class<T> dbClass, @Nullable CoroutineDispatcher queryDispatcher) {
+        this(dbClass, queryDispatcher != null ? ExecutorsKt.asExecutor(queryDispatcher) : null);
+    }
+
+    public RoomDatabaseRule(@NonNull Class<T> dbClass, @Nullable Executor queryExecutor) {
+        mDbClass = dbClass;
+        mQueryExecutor = queryExecutor;
+    }
+
+    @NonNull
+    private final Class<T> mDbClass;
+    @Nullable
+    private final Executor mQueryExecutor;
+
+    @Nullable
+    private T mDb;
+
+    @NonNull
+    public T getDb() {
+        if (mDb == null) throw new IllegalStateException();
+        return mDb;
+    }
+
+    @Override
+    protected void starting(Description description) {
+        mDb = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(), mDbClass)
+                .allowMainThreadQueries()
+                .setQueryExecutor(mQueryExecutor != null ? mQueryExecutor : ArchTaskExecutor.getIOThreadExecutor())
+                .setTransactionExecutor(ArchTaskExecutor.getIOThreadExecutor())
+                .build();
+    }
+
+    @Override
+    protected void finished(Description description) {
+        if (mDb != null) mDb.close();
+        mDb = null;
+    }
+}


### PR DESCRIPTION
This PR creates a junit `Rule` that will provide an instance of a room database that can be used for unit tests.

This will currently be used with a couple different Room databases within GodTools.