### PR TITLE
GT-1911 when R8 full mode is enabled we need to ensure we keep the annotation classes as well

### DIFF
--- a/gto-support-jsonapi/proguard-consumer.pro
+++ b/gto-support-jsonapi/proguard-consumer.pro
@@ -1,5 +1,6 @@
 # Make sure we keep annotations, fields, and methods for any jsonapi model
 -keepattributes *Annotation*
+-keep class org.ccci.gto.android.common.jsonapi.annotation.*
 -keepclassmembers @org.ccci.gto.android.common.jsonapi.annotation.JsonApiType class ** {
   <fields>;
   @org.ccci.gto.android.common.jsonapi.annotation.JsonApiPostCreate <methods>;


### PR DESCRIPTION
see: https://issuetracker.google.com/issues/252388315
see: https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md
proguard configuration documentation: https://www.guardsquare.com/manual/configuration/usage

How I tracked it down to this was I discovered the objects being parsed from the API were only partially parsed when they were being saved to the database. The fields missing were the fields where the json attribute names didn't match the field name.