### PR TITLE
GT-1944 Add a few TokenStorage helpers

### DIFF
--- a/gto-support-okta/src/main/java/com/okta/authfoundation/credential/SharedPreferencesTokenStorageInternals.java
+++ b/gto-support-okta/src/main/java/com/okta/authfoundation/credential/SharedPreferencesTokenStorageInternals.java
@@ -1,19 +1,26 @@
 package com.okta.authfoundation.credential;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 
 import com.okta.authfoundation.client.OidcClient;
 
+import org.ccci.gto.android.common.util.lang.ClassKt;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 @RestrictTo(RestrictTo.Scope.LIBRARY)
+@SuppressWarnings("KotlinInternalInJava")
 public class SharedPreferencesTokenStorageInternals {
     @RequiresApi(Build.VERSION_CODES.M)
-    @SuppressWarnings("KotlinInternalInJava")
     public static SharedPreferencesTokenStorage create(
             @NonNull final OidcClient client,
             @NonNull final Context context,
@@ -26,5 +33,19 @@ public class SharedPreferencesTokenStorageInternals {
                 context,
                 keyGenParameterSpec
         );
+    }
+
+    @Nullable
+    @RequiresApi(Build.VERSION_CODES.M)
+    public static SharedPreferences getSharedPreferences(SharedPreferencesTokenStorage storage) throws Throwable {
+        Method method = ClassKt.getDeclaredMethodOrNull(SharedPreferencesTokenStorage.class, "getSharedPreferences()");
+        if (method != null) {
+            try {
+                return (SharedPreferences) method.invoke(storage);
+            } catch (InvocationTargetException e) {
+                throw e.getCause() != null ? e.getCause() : e;
+            }
+        }
+        return null;
     }
 }

--- a/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/authfoundation/credential/MigrationTokenStorage.kt
+++ b/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/authfoundation/credential/MigrationTokenStorage.kt
@@ -1,0 +1,46 @@
+package org.ccci.gto.android.common.okta.authfoundation.credential
+
+import com.okta.authfoundation.credential.TokenStorage
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class MigrationTokenStorage(
+    private val storage: TokenStorage,
+    private val originalStorage: TokenStorage,
+) : TokenStorage, ChangeAwareTokenStorage, TokenStorageObserverRegistry by DefaultTokenStorageObserverRegistry() {
+    private val migrationMutex = Mutex()
+    private var isMigrated = false
+
+    private suspend fun migrateStorage() {
+        if (isMigrated) return
+
+        migrationMutex.withLock {
+            if (isMigrated) return@withLock
+            originalStorage.migrateTo(storage)
+            isMigrated = true
+        }
+    }
+
+    override suspend fun add(id: String) {
+        migrateStorage()
+        storage.add(id)
+        notifyChanged(id)
+    }
+
+    override suspend fun entries(): List<TokenStorage.Entry> {
+        migrateStorage()
+        return storage.entries()
+    }
+
+    override suspend fun remove(id: String) {
+        migrateStorage()
+        storage.remove(id)
+        notifyChanged(id)
+    }
+
+    override suspend fun replace(updatedEntry: TokenStorage.Entry) {
+        migrateStorage()
+        storage.replace(updatedEntry)
+        notifyChanged(updatedEntry.identifier)
+    }
+}

--- a/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/authfoundation/credential/SharedPreferencesTokenStorage.kt
+++ b/gto-support-okta/src/main/kotlin/org/ccci/gto/android/common/okta/authfoundation/credential/SharedPreferencesTokenStorage.kt
@@ -14,4 +14,6 @@ fun SharedPreferencesTokenStorage(
     client: OidcClient,
     context: Context,
     keyGenParameterSpec: KeyGenParameterSpec = MasterKeys.AES256_GCM_SPEC,
+    verify: Boolean = false,
 ): TokenStorage = SharedPreferencesTokenStorageInternals.create(client, context, keyGenParameterSpec)
+    .also { if (verify) SharedPreferencesTokenStorageInternals.getSharedPreferences(it) }

--- a/gto-support-okta/src/main/proguard-consumer.pro
+++ b/gto-support-okta/src/main/proguard-consumer.pro
@@ -2,3 +2,8 @@
     # keep for com.okta.authfoundation.credential.CredentialDataSourceInternalsKt#storageField
     com.okta.authfoundation.credential.TokenStorage storage;
 }
+
+-keepclassmembernames class com.okta.authfoundation.credential.SharedPreferencesTokenStorage {
+    # keep for com.okta.authfoundation.credential.SharedPreferencesTokenStorageInternals#getSharedPreferences()
+    android.content.SharedPreferences getSharedPreferences();
+}


### PR DESCRIPTION
A few Android devices have been unable to instantiate `SharedPreferencesTokenStorage` due to not being able to generate encryption keys.

The exception for accessing encryption keys is being thrown on a background thread due to the default behavior of using coroutines to interact with the TokenStorage. The actual exception is being generated when instantiating a private internal val in `SharedPreferencesTokenStorage` which can be manually triggered using reflection.

This PR adds an optional `verify` flag that can be used when creating the `SharedPreferencesTokenStorage` that will "verify" the `TokenStorage` is usable.

Unrelated to this I also introduced a `MigrationTokenStorage` class that will automatically migrate tokens from an old storage mechanism to a new storage mechanism on first use. This will be used to more reliably migrate tokens from our fallback token storage provider to our preferred one.