### PR TITLE
GT-1922 Use a string to represent Locales on js

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Run JS Unit Tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jsTest --scan
+          arguments: jsBrowserTest jsNodeTest --scan
       - name: Archive test results
         if: always()
         uses: actions/upload-artifact@v3

--- a/buildSrc/src/main/kotlin/MultiplatformConfiguration.kt
+++ b/buildSrc/src/main/kotlin/MultiplatformConfiguration.kt
@@ -66,5 +66,11 @@ fun KotlinMultiplatformExtension.configureIosTargets() {
 }
 
 fun KotlinMultiplatformExtension.configureJsTargets() {
-    js { nodejs() }
+    js {
+        binaries.library()
+        browser {
+            testTask { useMocha() }
+        }
+        nodejs()
+    }
 }

--- a/gto-support-fluidsonic-locale/src/jsMain/kotlin/org/ccci/gto/support/fluidsonic/locale/PlatformLocale.js.kt
+++ b/gto-support-fluidsonic-locale/src/jsMain/kotlin/org/ccci/gto/support/fluidsonic/locale/PlatformLocale.js.kt
@@ -1,10 +1,7 @@
 package org.ccci.gto.support.fluidsonic.locale
 
-import io.fluidsonic.locale.Intl
 import io.fluidsonic.locale.Locale
-import io.fluidsonic.locale.toCommon
-import io.fluidsonic.locale.toPlatform
 
-actual typealias PlatformLocale = Intl.Locale
-actual fun Locale.toPlatform() = toPlatform()
-actual fun PlatformLocale.toCommon() = toCommon()
+actual typealias PlatformLocale = String
+actual fun Locale.toPlatform() = toString()
+actual fun PlatformLocale.toCommon() = Locale.forLanguageTag(this)


### PR DESCRIPTION
- use a String instead of Intl.Locale for javascript
- target both nodejs and browsers for Kotlin/JS libraries
