### PR TITLE
Some updates to gto-support-okta-oidc

### DIFF
--- a/gto-support-okta-oidc/build.gradle.kts
+++ b/gto-support-okta-oidc/build.gradle.kts
@@ -30,4 +30,5 @@ dependencies {
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.kotlin.coroutines.test)
     testImplementation(libs.bundles.okhttp3.mockwebserver)
+    testImplementation(libs.turbine)
 }

--- a/gto-support-okta-oidc/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/OktaUserProfileProvider.kt
+++ b/gto-support-okta-oidc/src/main/kotlin/org/ccci/gto/android/common/okta/oidc/OktaUserProfileProvider.kt
@@ -8,9 +8,9 @@ import com.okta.oidc.storage.OktaRepository
 import com.okta.oidc.util.AuthorizationException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.channels.actor
@@ -36,7 +36,7 @@ import org.ccci.gto.android.common.okta.oidc.net.response.oktaUserId
 import org.ccci.gto.android.common.okta.oidc.storage.getPersistableUserInfo
 
 @SuppressLint("RestrictedApi")
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class, ObsoleteCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
 class OktaUserProfileProvider @VisibleForTesting internal constructor(
     private val sessionClient: SessionClient,
     private val oktaRepo: OktaRepository = sessionClient.oktaRepo,

--- a/gto-support-okta-oidc/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/BaseOktaOidcTest.kt
+++ b/gto-support-okta-oidc/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/BaseOktaOidcTest.kt
@@ -4,14 +4,16 @@ import com.okta.oidc.Okta
 import com.okta.oidc.clients.web.WebAuthClient
 import com.okta.oidc.net.OktaHttpClient
 import com.okta.oidc.storage.OktaStorage
+import kotlinx.coroutines.test.TestScope
 import org.ccci.gto.android.common.okta.oidc.storage.security.NoopEncryptionManager
 import org.junit.Before
 import org.mockito.kotlin.mock
 
 abstract class BaseOktaOidcTest(
     protected open val httpClient: OktaHttpClient = mock(),
-    protected open val storage: OktaStorage = mock()
+    protected open val storage: OktaStorage = mock(),
 ) {
+    protected val testScope = TestScope()
     protected lateinit var webAuthClient: WebAuthClient
 
     @Before

--- a/gto-support-okta-oidc/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/OktaUserProfileProviderTest.kt
+++ b/gto-support-okta-oidc/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/OktaUserProfileProviderTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -48,7 +47,6 @@ internal class OktaUserProfileProviderTest : BaseOktaOidcTest() {
     private lateinit var sessionClient: SessionClient
     override val storage = mock<OktaStorage>().makeChangeAware() as ChangeAwareOktaStorage
     private lateinit var oktaRepo: OktaRepository
-    private val testScope = TestScope()
 
     private lateinit var provider: OktaUserProfileProvider
 

--- a/gto-support-okta-oidc/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/clients/sessions/SessionClientCoroutinesTest.kt
+++ b/gto-support-okta-oidc/src/test/kotlin/org/ccci/gto/android/common/okta/oidc/clients/sessions/SessionClientCoroutinesTest.kt
@@ -1,0 +1,58 @@
+package org.ccci.gto.android.common.okta.oidc.clients.sessions
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.okta.oidc.Tokens
+import com.okta.oidc.clients.sessions.SessionClient
+import com.okta.oidc.storage.OktaStorage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.test.runTest
+import org.ccci.gto.android.common.okta.oidc.BaseOktaOidcTest
+import org.ccci.gto.android.common.okta.oidc.ID_TOKEN
+import org.ccci.gto.android.common.okta.oidc.storage.ChangeAwareOktaStorage
+import org.ccci.gto.android.common.okta.oidc.storage.makeChangeAware
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class SessionClientCoroutinesTest : BaseOktaOidcTest() {
+    override val storage = mockk<OktaStorage>().makeChangeAware() as ChangeAwareOktaStorage
+    private val tokens: Tokens = mockk {
+        every { idToken } returns null
+    }
+
+    private lateinit var sessionClient: SessionClient
+
+    @Before
+    fun setupSessionClient() {
+        sessionClient = spyk(webAuthClient.sessionClient) {
+            every { tokens } returns this@SessionClientCoroutinesTest.tokens
+        }
+    }
+
+    @Test
+    fun `changeFlow()`() = testScope.runTest {
+        sessionClient.changeFlow().test {
+            awaitItem()
+
+            storage.notifyChanged()
+            awaitItem()
+        }
+    }
+
+    @Test
+    fun `idTokenFlow()`() = testScope.runTest {
+        sessionClient.idTokenFlow().test {
+            assertNull(awaitItem())
+
+            every { tokens.idToken } returns ID_TOKEN
+            storage.notifyChanged()
+            assertNotNull(awaitItem())
+        }
+    }
+}


### PR DESCRIPTION
- add unit tests for sessionClient.changeFlow() and SessionClient.idTokenFlow()
- cleanup OptIn annotations for OktaUserProfileProvider
- use MockK for the Tokens mock
