### PR TITLE
Support a CoroutineScope for RoomDatabases

### DIFF
--- a/gto-support-androidx-room/src/main/kotlin/org/ccci/gto/android/common/androidx/room/RoomDatabase+Coroutines.kt
+++ b/gto-support-androidx-room/src/main/kotlin/org/ccci/gto/android/common/androidx/room/RoomDatabase+Coroutines.kt
@@ -1,0 +1,15 @@
+package org.ccci.gto.android.common.androidx.room
+
+import android.annotation.SuppressLint
+import androidx.room.RoomDatabase
+import androidx.room.getQueryDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+
+internal const val FIELD_COROUTINE_SCOPE = "GtoCoroutineScope"
+
+val RoomDatabase.coroutineScope
+    @SuppressLint("RestrictedApi")
+    get() = backingFieldMap.getOrPut(FIELD_COROUTINE_SCOPE) {
+        CoroutineScope(getQueryDispatcher() + SupervisorJob())
+    } as CoroutineScope

--- a/gto-support-androidx-room/src/testFixtures/java/org/ccci/gto/android/common/androidx/room/TestRoomDatabaseCoroutines.java
+++ b/gto-support-androidx-room/src/testFixtures/java/org/ccci/gto/android/common/androidx/room/TestRoomDatabaseCoroutines.java
@@ -1,0 +1,14 @@
+package org.ccci.gto.android.common.androidx.room;
+
+import android.annotation.SuppressLint;
+
+import androidx.room.RoomDatabase;
+
+import kotlinx.coroutines.CoroutineScope;
+
+public class TestRoomDatabaseCoroutines {
+    @SuppressLint("RestrictedApi")
+    public static void setCoroutineScope(RoomDatabase db, CoroutineScope scope) {
+        db.getBackingFieldMap().put(RoomDatabase_CoroutinesKt.FIELD_COROUTINE_SCOPE, scope);
+    }
+}


### PR DESCRIPTION
This will allow us to launch background tasks from within a RoomDatabase. Our immediate need for this is that in GodTools we track a lastAccessed time for Translations. We want to update the timestamp in the background anytime the code actually retrieves the Translation from the database.