### PR TITLE
Create some ViewModel testFixtures

### DIFF
--- a/gto-support-androidx-lifecycle/build.gradle.kts
+++ b/gto-support-androidx-lifecycle/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 android {
     namespace = "org.ccci.gto.android.common.androidx.lifecycle"
     configureCompose(project)
+    testFixtures.enable = true
 }
 
 dependencies {
@@ -26,6 +27,8 @@ dependencies {
     // region SavedStateHandle
     compileOnly(libs.androidx.lifecycle.viewmodel.savedstate)
     // endregion SavedStateHandle
+
+    testFixturesApi(libs.androidx.lifecycle.viewmodel)
 
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.androidx.core.ktx)

--- a/gto-support-androidx-lifecycle/src/main/kotlin/androidx/lifecycle/ViewModelInternals.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/androidx/lifecycle/ViewModelInternals.kt
@@ -1,3 +1,0 @@
-package androidx.lifecycle
-
-internal fun <T : Any> ViewModel.setTagIfAbsent(key: String, value: T?): T? = setTagIfAbsent(key, value)

--- a/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+ViewModel.kt
+++ b/gto-support-androidx-lifecycle/src/main/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveData+ViewModel.kt
@@ -4,18 +4,12 @@ import androidx.annotation.MainThread
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.setTagIfAbsent
 import com.karumi.weak.weak
 import java.io.Closeable
-import java.util.concurrent.atomic.AtomicInteger
 
-private val OBSERVER_INDEX = AtomicInteger(0)
 fun <O, T : O> LiveData<T>.observe(viewModel: ViewModel, observer: Observer<O>): Observer<O> {
     observeForever(observer)
-    viewModel.setTagIfAbsent(
-        "LiveDataObserver-${OBSERVER_INDEX.getAndIncrement()}",
-        WeakCloseableObserverWrapper(this, observer)
-    )
+    viewModel.addCloseable(WeakCloseableObserverWrapper(this, observer))
     return observer
 }
 

--- a/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveDataViewModelObserverTest.kt
+++ b/gto-support-androidx-lifecycle/src/test/kotlin/org/ccci/gto/android/common/androidx/lifecycle/LiveDataViewModelObserverTest.kt
@@ -2,7 +2,7 @@ package org.ccci.gto.android.common.androidx.lifecycle
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.clear
+import androidx.lifecycle.ViewModelTestInternals
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -27,7 +27,7 @@ class LiveDataViewModelObserverTest : BaseLiveDataTest() {
 
     @After
     fun cleanup() {
-        viewModel.clear()
+        ViewModelTestInternals.clear(viewModel)
     }
 
     @Test
@@ -36,7 +36,7 @@ class LiveDataViewModelObserverTest : BaseLiveDataTest() {
         liveData.value = 1
         verify(observer).onChanged(any())
 
-        viewModel.clear()
+        ViewModelTestInternals.clear(viewModel)
         liveData.value = 2
         verifyNoMoreInteractions(observer)
     }
@@ -114,7 +114,7 @@ class LiveDataViewModelObserverTest : BaseLiveDataTest() {
         liveData.observeOnce(viewModel, observer)
 
         // Lifecycle is destroyed so observer is removed before it can be called
-        viewModel.clear()
+        ViewModelTestInternals.clear(viewModel)
         liveData.value = 1
         verify(observer, never()).invoke(any())
     }

--- a/gto-support-androidx-lifecycle/src/testFixtures/java/androidx/lifecycle/ViewModelTestInternals.java
+++ b/gto-support-androidx-lifecycle/src/testFixtures/java/androidx/lifecycle/ViewModelTestInternals.java
@@ -1,0 +1,10 @@
+package androidx.lifecycle;
+
+// TODO: convert this to Kotlin once Android Test Fixtures support Kotlin
+//       https://youtrack.jetbrains.com/issue/KT-50667
+//       https://issuetracker.google.com/issues/259523353
+public class ViewModelTestInternals {
+    public static void clear(ViewModel viewModel) {
+        viewModel.clear();
+    }
+}


### PR DESCRIPTION
- provide a viewmodel test fixture that allows a test to clear a ViewModel
- switch ViewModel LiveData extensions to utilize addObservable
