### PR TITLE
GT-1985 create an annotatedStringResource() composable

### DIFF
--- a/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/res/AnnotatedStringResources.kt
+++ b/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/res/AnnotatedStringResources.kt
@@ -1,0 +1,33 @@
+package org.ccci.gto.android.common.androidx.compose.ui.text.res
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.core.os.ConfigurationCompat
+import java.util.Formattable
+import java.util.Formatter
+
+@Composable
+@ReadOnlyComposable
+fun annotatedStringResource(@StringRes id: Int, vararg formatArgs: Any) = buildAnnotatedString {
+    LocalConfiguration.current
+    val args = formatArgs.map { if (it is AnnotatedString) AnnotatedStringFormattable(it) else it }
+    Formatter(this, ConfigurationCompat.getLocales(LocalContext.current.resources.configuration)[0])
+        .format(stringResource(id), *args.toTypedArray())
+}
+
+private class AnnotatedStringFormattable(private val text: AnnotatedString) : Formattable {
+    override fun formatTo(formatter: Formatter, flags: Int, width: Int, precision: Int) {
+        when (val out = formatter.out()) {
+            is AnnotatedString.Builder -> out.append(text)
+            else -> out.append(text)
+        }
+    }
+
+    override fun toString() = text.toString()
+}

--- a/gto-support-androidx-compose/src/testDebug/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/res/AnnotatedStringResourcesTest.kt
+++ b/gto-support-androidx-compose/src/testDebug/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/res/AnnotatedStringResourcesTest.kt
@@ -1,0 +1,45 @@
+package org.ccci.gto.android.common.androidx.compose.ui.text.res
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.ccci.gto.android.common.androidx.compose.test.R
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AnnotatedStringResourcesTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `annotatedStringResource() - String`() {
+        composeTestRule.setContent {
+            val string = annotatedStringResource(R.string.annotated_string_format, "middle")
+            assertEquals("start middle end", string.toString())
+        }
+    }
+
+    @Test
+    fun `annotatedStringResource() - AnnotatedString`() {
+        composeTestRule.setContent {
+            val style = SpanStyle(color = Color.Cyan)
+            val arg = buildAnnotatedString {
+                withStyle(style) { append("middle") }
+            }
+            val string = annotatedStringResource(R.string.annotated_string_format, arg)
+            assertEquals("start middle end", string.toString())
+
+            string.spanStyles.single().let {
+                assertEquals(6, it.start)
+                assertEquals(style, it.item)
+                assertEquals(12, it.end)
+            }
+        }
+    }
+}

--- a/gto-support-androidx-compose/src/testDebug/res/values/strings.xml
+++ b/gto-support-androidx-compose/src/testDebug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="annotated_string_format">start %1$s end</string>
+</resources>


### PR DESCRIPTION
this composable supports taking AnnotatedStrings as format args and preserving any annotations attached to them
