### PR TITLE
add a source compatible hasErrors() method back to JsonApiObject

### DIFF
--- a/gto-support-jsonapi/src/main/kotlin/org/ccci/gto/android/common/jsonapi/model/JsonApiObject.kt
+++ b/gto-support-jsonapi/src/main/kotlin/org/ccci/gto/android/common/jsonapi/model/JsonApiObject.kt
@@ -56,6 +56,11 @@ open class JsonApiObject<T : Any> private constructor(
         dataSingle = data
     }
 
+    @JvmSynthetic
+    @JvmName("-hasErrors")
+    @Deprecated("Since v4.1.0, use hasErrors property instead.", ReplaceWith("hasErrors"))
+    fun hasErrors() = hasErrors
+
     @Deprecated("Since v4.1.0, use errors += error instead", ReplaceWith("errors += error"))
     fun addError(error: JsonApiError) {
         errors += error


### PR DESCRIPTION
This is to aid migrations
