### PR TITLE
Handle object cycles when converting to jsonapi

### DIFF
--- a/gto-support-jsonapi-core/src/main/java/org/ccci/gto/android/common/jsonapi/JsonApiConverter.java
+++ b/gto-support-jsonapi-core/src/main/java/org/ccci/gto/android/common/jsonapi/JsonApiConverter.java
@@ -149,14 +149,24 @@ public final class JsonApiConverter {
                 if (resource == null) {
                     json.put(JSON_DATA, JSONObject.NULL);
                 } else {
-                    json.put(JSON_DATA, resourceToJson(resource, options, includes, related, anonymousRelated, false));
+                    final JSONObject data =
+                            resourceToJson(resource, options, includes, related, anonymousRelated, false);
+                    json.put(JSON_DATA, data);
+                    if (data != null) {
+                        related.remove(ObjKey.create(data));
+                    }
                 }
             } else {
-                final JSONArray dataArr = new JSONArray();
+                final List<JSONObject> dataArr = new ArrayList<>();
                 for (final Object resource : obj.getData()) {
-                    dataArr.put(resourceToJson(resource, options, includes, related, anonymousRelated, false));
+                    dataArr.add(resourceToJson(resource, options, includes, related, anonymousRelated, false));
                 }
-                json.put(JSON_DATA, dataArr);
+                for (final JSONObject data : dataArr) {
+                    if (data != null) {
+                        related.remove(ObjKey.create(data));
+                    }
+                }
+                json.put(JSON_DATA, new JSONArray(dataArr));
             }
 
             // include related objects if there are any

--- a/gto-support-jsonapi-core/src/main/java/org/ccci/gto/android/common/jsonapi/JsonApiConverter.java
+++ b/gto-support-jsonapi-core/src/main/java/org/ccci/gto/android/common/jsonapi/JsonApiConverter.java
@@ -7,6 +7,7 @@ import org.ccci.gto.android.common.jsonapi.annotation.JsonApiPlaceholder;
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiPostCreate;
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType;
 import org.ccci.gto.android.common.jsonapi.converter.TypeConverter;
+import org.ccci.gto.android.common.jsonapi.internal.util.ObjKey;
 import org.ccci.gto.android.common.jsonapi.internal.util.ReflectionUtils;
 import org.ccci.gto.android.common.jsonapi.model.JsonApiError;
 import org.ccci.gto.android.common.jsonapi.model.JsonApiObject;
@@ -403,7 +404,7 @@ public final class JsonApiConverter {
                     final JSONObject relatedObj =
                             resourceToJson(field.mField.get(resource), options, include.descendant(attrName), related,
                                            anonymousRelated);
-                    final ObjKey key = ObjKey.create(relatedObj);
+                    final ObjKey key = relatedObj != null ? ObjKey.create(relatedObj) : null;
                     if (key != null) {
                         final JSONObject reference =
                                 new JSONObject(relatedObj, new String[] {JSON_DATA_TYPE, JSON_DATA_ID});
@@ -427,7 +428,7 @@ public final class JsonApiConverter {
                             final JSONObject relatedObj =
                                     resourceToJson(obj, options, include.descendant(attrName), related,
                                                    anonymousRelated);
-                            final ObjKey key = ObjKey.create(relatedObj);
+                            final ObjKey key = relatedObj != null ? ObjKey.create(relatedObj) : null;
                             if (key != null) {
                                 objs.put(new JSONObject(relatedObj, new String[] {JSON_DATA_TYPE, JSON_DATA_ID}));
 
@@ -452,7 +453,7 @@ public final class JsonApiConverter {
                             final JSONObject relatedObj =
                                     resourceToJson(obj, options, include.descendant(attrName), related,
                                                    anonymousRelated);
-                            final ObjKey key = ObjKey.create(relatedObj);
+                            final ObjKey key = relatedObj != null ? ObjKey.create(relatedObj) : null;
                             if (key != null) {
                                 objs.put(new JSONObject(relatedObj, new String[] {JSON_DATA_TYPE, JSON_DATA_ID}));
 
@@ -1113,49 +1114,6 @@ public final class JsonApiConverter {
                 return true;
             }
             return false;
-        }
-    }
-
-    static final class ObjKey {
-        @NonNull
-        final String mType;
-        @NonNull
-        final String mId;
-
-        ObjKey(@NonNull final String type, @NonNull final String id) {
-            mType = type;
-            mId = id;
-        }
-
-        @Nullable
-        static ObjKey create(@Nullable final JSONObject json) {
-            if (json != null) {
-                final String type = !json.isNull(JSON_DATA_TYPE) ? json.optString(JSON_DATA_TYPE, null) : null;
-                final String id = !json.isNull(JSON_DATA_ID) ? json.optString(JSON_DATA_ID, null) : null;
-                if (type != null && id != null) {
-                    return new ObjKey(type, id);
-                }
-            }
-
-            return null;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (!(o instanceof ObjKey)) {
-                return false;
-            }
-
-            final ObjKey that = (ObjKey) o;
-            return mType.equals(that.mType) && mId.equals(that.mId);
-        }
-
-        @Override
-        public int hashCode() {
-            return Arrays.hashCode(new Object[] {mType, mId});
         }
     }
 

--- a/gto-support-jsonapi-core/src/main/kotlin/org/ccci/gto/android/common/jsonapi/internal/util/ObjKey.kt
+++ b/gto-support-jsonapi-core/src/main/kotlin/org/ccci/gto/android/common/jsonapi/internal/util/ObjKey.kt
@@ -1,0 +1,17 @@
+package org.ccci.gto.android.common.jsonapi.internal.util
+
+import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
+import org.json.JSONObject
+
+internal data class ObjKey(val type: String, val id: String) {
+    companion object {
+        @JvmStatic
+        @JvmName("create")
+        internal fun JSONObject.toObjKey(): ObjKey? {
+            val type = optString(JsonApiObject.JSON_DATA_TYPE, null) ?: return null
+            val id = optString(JsonApiObject.JSON_DATA_ID, null) ?: return null
+
+            return ObjKey(type, id)
+        }
+    }
+}

--- a/gto-support-jsonapi-core/src/test/kotlin/org/ccci/gto/android/common/jsonapi/JsonApiConverterCycleRelationshipTest.kt
+++ b/gto-support-jsonapi-core/src/test/kotlin/org/ccci/gto/android/common/jsonapi/JsonApiConverterCycleRelationshipTest.kt
@@ -1,0 +1,57 @@
+package org.ccci.gto.android.common.jsonapi
+
+import kotlin.test.Test
+import net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import org.ccci.gto.android.common.jsonapi.JsonApiConverter.Options
+import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
+import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
+import org.ccci.gto.android.common.jsonapi.model.ModelBase
+
+class JsonApiConverterCycleRelationshipTest {
+    private val obj = ModelCycle(1).apply {
+        cycle = ModelCycle(2, this)
+    }
+
+    @Test
+    fun `toJson(cycleObj) - Include relationships - none`() {
+        val converter = JsonApiConverter.Builder()
+            .addClasses(ModelCycle::class.java)
+            .build()
+        val options = Options.builder().include().build()
+
+        val json = converter.toJson(JsonApiObject.single(obj), options)
+        assertThatJson(json).node("data").isObject()
+        assertThatJson(json).node("data.id").isEqualTo(obj.id)
+        assertThatJson(json).node("data.type").isEqualTo(ModelCycle.JSONAPI_TYPE)
+        assertThatJson(json).node("data.relationships.cycle.data.id").isEqualTo(obj.cycle?.id)
+        assertThatJson(json).node("included").isAbsent
+    }
+
+    @Test
+    fun `toJson(cycleObj) - Include relationships - depth 1`() {
+        val converter = JsonApiConverter.Builder()
+            .addClasses(ModelCycle::class.java)
+            .build()
+        val options = Options.builder().include("cycle").build()
+
+        val json = converter.toJson(JsonApiObject.single(obj), options)
+        assertThatJson(json).node("data").isObject()
+        assertThatJson(json).node("data.id").isEqualTo(obj.id)
+        assertThatJson(json).node("data.type").isEqualTo(ModelCycle.JSONAPI_TYPE)
+        assertThatJson(json).node("data.relationships.cycle.data.id").isEqualTo(obj.cycle?.id)
+        assertThatJson(json).node("included").isArray.ofLength(1)
+        assertThatJson(json).node("included[0].id").isEqualTo(obj.cycle?.id)
+        assertThatJson(json).node("included[0].type").isEqualTo(ModelCycle.JSONAPI_TYPE)
+        assertThatJson(json).node("included[0].relationships.cycle.data.id").isEqualTo(obj.cycle?.cycle?.id)
+    }
+
+    @JsonApiType(ModelCycle.JSONAPI_TYPE)
+    class ModelCycle(
+        id: Int,
+        var cycle: ModelCycle? = null,
+    ) : ModelBase(id) {
+        companion object {
+            const val JSONAPI_TYPE = "cycle"
+        }
+    }
+}

--- a/gto-support-jsonapi-core/src/test/kotlin/org/ccci/gto/android/common/jsonapi/JsonApiConverterCycleRelationshipTest.kt
+++ b/gto-support-jsonapi-core/src/test/kotlin/org/ccci/gto/android/common/jsonapi/JsonApiConverterCycleRelationshipTest.kt
@@ -64,6 +64,24 @@ class JsonApiConverterCycleRelationshipTest {
     }
 
     @Test
+    fun `toJson(cycleObj) - Include relationships - depth infinity`() {
+        val converter = JsonApiConverter.Builder()
+            .addClasses(ModelCycle::class.java)
+            .build()
+        val options = Options.builder().includeAll().build()
+
+        val json = converter.toJson(JsonApiObject.single(obj), options)
+        assertThatJson(json).node("data").isObject()
+        assertThatJson(json).node("data.id").isEqualTo(obj.id)
+        assertThatJson(json).node("data.type").isEqualTo(ModelCycle.JSONAPI_TYPE)
+        assertThatJson(json).node("data.relationships.cycle.data.id").isEqualTo(obj.cycle?.id)
+        assertThatJson(json).node("included").isArray.ofLength(1)
+        assertThatJson(json).node("included[0].id").isEqualTo(2)
+        assertThatJson(json).node("included[0].type").isEqualTo(ModelCycle.JSONAPI_TYPE)
+        assertThatJson(json).node("included[0].relationships.cycle.data.id").isEqualTo(obj.cycle?.cycle?.id)
+    }
+
+    @Test
     fun `toJson(cycleObj) - Include relationships - reference other data - depth 2`() {
         val converter = JsonApiConverter.Builder()
             .addClasses(ModelCycle::class.java)

--- a/gto-support-jsonapi-core/src/test/kotlin/org/ccci/gto/android/common/jsonapi/JsonApiConverterCycleRelationshipTest.kt
+++ b/gto-support-jsonapi-core/src/test/kotlin/org/ccci/gto/android/common/jsonapi/JsonApiConverterCycleRelationshipTest.kt
@@ -45,6 +45,42 @@ class JsonApiConverterCycleRelationshipTest {
         assertThatJson(json).node("included[0].relationships.cycle.data.id").isEqualTo(obj.cycle?.cycle?.id)
     }
 
+    @Test
+    fun `toJson(cycleObj) - Include relationships - depth 2`() {
+        val converter = JsonApiConverter.Builder()
+            .addClasses(ModelCycle::class.java)
+            .build()
+        val options = Options.builder().include("cycle.cycle").build()
+
+        val json = converter.toJson(JsonApiObject.single(obj), options)
+        assertThatJson(json).node("data").isObject()
+        assertThatJson(json).node("data.id").isEqualTo(obj.id)
+        assertThatJson(json).node("data.type").isEqualTo(ModelCycle.JSONAPI_TYPE)
+        assertThatJson(json).node("data.relationships.cycle.data.id").isEqualTo(obj.cycle?.id)
+        assertThatJson(json).node("included").isArray.ofLength(1)
+        assertThatJson(json).node("included[0].id").isEqualTo(obj.cycle?.id)
+        assertThatJson(json).node("included[0].type").isEqualTo(ModelCycle.JSONAPI_TYPE)
+        assertThatJson(json).node("included[0].relationships.cycle.data.id").isEqualTo(obj.cycle?.cycle?.id)
+    }
+
+    @Test
+    fun `toJson(cycleObj) - Include relationships - reference other data - depth 2`() {
+        val converter = JsonApiConverter.Builder()
+            .addClasses(ModelCycle::class.java)
+            .build()
+        val options = Options.builder().include("cycle.cycle").build()
+
+        val json = converter.toJson(JsonApiObject.of(obj, obj.cycle!!), options)
+        assertThatJson(json).node("data").isArray.ofLength(2)
+        assertThatJson(json).node("data[0].id").isEqualTo(obj.id)
+        assertThatJson(json).node("data[0].type").isEqualTo(ModelCycle.JSONAPI_TYPE)
+        assertThatJson(json).node("data[0].relationships.cycle.data.id").isEqualTo(obj.cycle?.id)
+        assertThatJson(json).node("data[1].id").isEqualTo(obj.cycle?.id)
+        assertThatJson(json).node("data[1].type").isEqualTo(ModelCycle.JSONAPI_TYPE)
+        assertThatJson(json).node("data[1].relationships.cycle.data.id").isEqualTo(obj.cycle?.cycle?.id)
+        assertThatJson(json).node("included").isAbsent
+    }
+
     @JsonApiType(ModelCycle.JSONAPI_TYPE)
     class ModelCycle(
         id: Int,


### PR DESCRIPTION
- convert ObjKey to Kotlin
- handle cycles in the object graph when not including all descendants
- don't include objects in the main data section in the included section
- handle unlimited include depth
