### PR TITLE
GT-1796 Support a JsonApiFields annotation for retrofit request bodies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,6 +80,7 @@ firebase-crashlytics = "com.google.firebase:firebase-crashlytics:18.4.3"
 fluidsonic-locale = "io.fluidsonic.locale:fluid-locale:0.13.0"
 json = "org.json:json:20230618"
 jsonUnit = { module = "net.javacrumbs.json-unit:json-unit", version.ref = "jsonUnit" }
+jsonUnit-assertj = { module = "net.javacrumbs.json-unit:json-unit-assertj", version.ref = "jsonUnit" }
 jsonUnit-fluent = { module = "net.javacrumbs.json-unit:json-unit-fluent", version.ref = "jsonUnit" }
 junit = { module = "junit:junit", version = "4.13.2" }
 junitParams = "pl.pragmatists:JUnitParams:1.1.1"

--- a/gto-support-jsonapi-retrofit2/build.gradle.kts
+++ b/gto-support-jsonapi-retrofit2/build.gradle.kts
@@ -25,8 +25,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(libs.json)
-                implementation(libs.jsonUnit)
-                implementation(libs.jsonUnit.fluent)
+                implementation(libs.jsonUnit.assertj)
                 implementation(libs.kotlin.coroutines.test)
                 implementation(libs.okhttp3.mockwebserver)
             }

--- a/gto-support-jsonapi-retrofit2/src/commonMain/kotlin/org/ccci/gto/android/common/jsonapi/retrofit2/annotation/JsonApiFields.kt
+++ b/gto-support-jsonapi-retrofit2/src/commonMain/kotlin/org/ccci/gto/android/common/jsonapi/retrofit2/annotation/JsonApiFields.kt
@@ -1,0 +1,19 @@
+package org.ccci.gto.android.common.jsonapi.retrofit2.annotation
+
+import androidx.annotation.RestrictTo
+
+/**
+ * This annotation is used with request body serialization to limit fields that are serialized in the generated JSON.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@JvmRepeatable(JsonApiFields.Container::class)
+annotation class JsonApiFields(
+    val type: String,
+    vararg val value: String = []
+) {
+    @Target(AnnotationTarget.VALUE_PARAMETER)
+    @Retention(AnnotationRetention.RUNTIME)
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    annotation class Container(val value: Array<JsonApiFields>)
+}


### PR DESCRIPTION
- convert to jsonunit-assertj for jsonapi-retrofit2
- add support for a JsonApiFields annotation for retrofit
