### PR TITLE
GT-2112 Support transforming input/output for ActivityResultContracts

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ scarlet = "0.1.12"
 accompanist-pager = { module = "com.google.accompanist:accompanist-pager", version.ref = "accompanist" }
 advancedrecyclerview = { module = "com.h6ah4i.android.widget.advrecyclerview:advrecyclerview", version = "1.0.0" }
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
+androidx-activity = "androidx.activity:activity:1.8.0"
 androidx-annotation = "androidx.annotation:annotation:1.7.0"
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
 androidx-arch-core-runtime = { module = "androidx.arch.core:core-runtime", version.ref = "androidx-arch-core" }

--- a/gto-support-androidx-activity/build.gradle.kts
+++ b/gto-support-androidx-activity/build.gradle.kts
@@ -3,3 +3,7 @@ plugins {
 }
 
 android.namespace = "org.ccci.gto.android.common.androidx.activity"
+
+dependencies {
+    api(libs.androidx.activity)
+}

--- a/gto-support-androidx-activity/build.gradle.kts
+++ b/gto-support-androidx-activity/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("gto-support.android-conventions")
+}
+
+android.namespace = "org.ccci.gto.android.common.androidx.activity"

--- a/gto-support-androidx-activity/src/main/kotlin/org/ccci/gto/android/common/androidx/activity/result/contract/TransformedActivityResultContract.kt
+++ b/gto-support-androidx-activity/src/main/kotlin/org/ccci/gto/android/common/androidx/activity/result/contract/TransformedActivityResultContract.kt
@@ -1,0 +1,42 @@
+package org.ccci.gto.android.common.androidx.activity.result.contract
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+
+private class TransformedActivityResultContract<I, O, NEW_I, NEW_O>(
+    private val baseContract: ActivityResultContract<I, O>,
+    private val inputTransform: (NEW_I) -> I,
+    private val outputTransform: (O) -> NEW_O,
+) : ActivityResultContract<NEW_I, NEW_O>() {
+    override fun createIntent(context: Context, input: NEW_I) =
+        baseContract.createIntent(context, inputTransform(input))
+
+    override fun parseResult(resultCode: Int, intent: Intent?) =
+        outputTransform(baseContract.parseResult(resultCode, intent))
+}
+
+fun <I, O, NEW_I, NEW_O> ActivityResultContract<I, O>.transform(
+    inputTransform: (NEW_I) -> I,
+    outputTransform: (O) -> NEW_O,
+): ActivityResultContract<NEW_I, NEW_O> = TransformedActivityResultContract(
+    baseContract = this,
+    inputTransform = inputTransform,
+    outputTransform = outputTransform,
+)
+
+fun <I, O, NEW_I> ActivityResultContract<I, O>.transformInput(
+    inputTransform: (NEW_I) -> I,
+): ActivityResultContract<NEW_I, O> = TransformedActivityResultContract(
+    baseContract = this,
+    inputTransform = inputTransform,
+    outputTransform = { it },
+)
+
+fun <I, O, NEW_O> ActivityResultContract<I, O>.transformOutput(
+    outputTransform: (O) -> NEW_O,
+): ActivityResultContract<I, NEW_O> = TransformedActivityResultContract(
+    baseContract = this,
+    inputTransform = { it },
+    outputTransform = outputTransform,
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,6 +40,7 @@ if (System.getenv("GITHUB_ACTIONS")?.toBoolean() == true) {
 
 includeBuild("build-logic")
 
+include("gto-support-androidx-activity")
 include("gto-support-androidx-annotation")
 include("gto-support-androidx-collection")
 include("gto-support-androidx-compose")


### PR DESCRIPTION
- create a new gto-support-androidx-activity module
- add some methods to transform input/output for an existing ActivityResultContract
