### PR TITLE
GT-2112 rename isAuthenticatedFlow to isExpiredFlow

### DIFF
--- a/gto-support-facebook/src/main/kotlin/org/ccci/gto/android/common/facebook/login/AccessToken.kt
+++ b/gto-support-facebook/src/main/kotlin/org/ccci/gto/android/common/facebook/login/AccessToken.kt
@@ -1,0 +1,14 @@
+package org.ccci.gto.android.common.facebook.login
+
+import com.facebook.AccessToken
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+
+fun AccessToken.isExpiredFlow() = flow {
+    while (!isExpired) {
+        emit(true)
+        delay((expires.time - System.currentTimeMillis()).coerceAtLeast(1))
+    }
+    emit(false)
+}.distinctUntilChanged()

--- a/gto-support-facebook/src/test/kotlin/org/ccci/gto/android/common/facebook/login/AccessTokenManagerTest.kt
+++ b/gto-support-facebook/src/test/kotlin/org/ccci/gto/android/common/facebook/login/AccessTokenManagerTest.kt
@@ -96,10 +96,10 @@ class AccessTokenManagerTest {
     }
     // endregion currentAccessTokenFlow()
 
-    // region isAuthenticatedFlow()
+    // region isExpiredFlow()
     @Test
-    fun `isAuthenticatedFlow()`() = runTest {
-        accessTokenManager.isAuthenticatedFlow().test {
+    fun `isExpiredFlow()`() = runTest {
+        accessTokenManager.isExpiredFlow().test {
             assertFalse(awaitItem())
             accessTokenManager.currentAccessToken = AccessToken(
                 "2",
@@ -121,7 +121,7 @@ class AccessTokenManagerTest {
             assertFalse(awaitItem())
         }
     }
-    // endregion isAuthenticatedFlow()
+    // endregion isExpiredFlow()
 
     // region refreshCurrentAccessToken()
     @Test


### PR DESCRIPTION
isAuthenticatedFlow may be a misnomer for this functionality, I'm unsure if token expiration and authentication status are equivalent in the facebook SDK
