### PR TITLE
cleanup

### DIFF
--- a/build-logic/src/main/kotlin/AndroidConfiguration.kt
+++ b/build-logic/src/main/kotlin/AndroidConfiguration.kt
@@ -60,7 +60,7 @@ private fun BaseExtension.configureTestOptions(project: Project) {
 
             all {
                 // increase unit tests max heap size
-                it.jvmArgs("-Xmx2g")
+                it.maxHeapSize = "2g"
             }
         }
     }

--- a/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/res/AnnotatedStringResources.kt
+++ b/gto-support-androidx-compose/src/main/kotlin/org/ccci/gto/android/common/androidx/compose/ui/text/res/AnnotatedStringResources.kt
@@ -15,6 +15,8 @@ import java.util.Formatter
 @Composable
 @ReadOnlyComposable
 fun annotatedStringResource(@StringRes id: Int, vararg formatArgs: Any) = buildAnnotatedString {
+    // We reference the LocalConfiguration to recompose if the configuration changes
+    // see: https://jetc.dev/slack/2022-02-13-why-resources-strange.html
     LocalConfiguration.current
     val args = formatArgs.map { if (it is AnnotatedString) AnnotatedStringFormattable(it) else it }
     Formatter(this, ConfigurationCompat.getLocales(LocalContext.current.resources.configuration)[0])


### PR DESCRIPTION
- add a note as to why we are referencing LocalConfiguration
- switch to the jvm max heap setting
- remove v3.13.0 deprecated getParcelableArray()
