### PR TITLE
feat(compose): add rememberStateFlow utility

### DIFF
--- a/.claude/skills/pr-review/dismissed-issues.md
+++ b/.claude/skills/pr-review/dismissed-issues.md
@@ -1,0 +1,5 @@
+## Jetbrains Compose library versions not sharing a version ref
+**Pattern**: Flagging that `compose-foundation`, `compose-runtime`, and `compose-ui` (Jetbrains Compose) use separate inline version strings or independent version refs rather than sharing a single version ref.
+**Reason**: Google announced these libraries may be versioned independently of each other, so keeping them as separate entries is intentional.
+**Dismissed**: 2026-04-23
+**Dismissed by**: Daniel Frett

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-arch-core = "2.2.0"
 androidx-collection = "1.6.0"
 androidx-compose = "1.10.6"
 androidx-compose-ui = "1.10.6"
+compose-ui = "1.10.3"
 androidx-core = "1.18.0"
 androidx-fragment = "1.8.9"
 androidx-lifecycle = "2.10.0"
@@ -76,7 +77,8 @@ androidx-work-runtime = { module = "androidx.work:work-runtime", version = "2.11
 circuit-overlay = { module = "com.slack.circuit:circuit-overlay", version.ref = "circuit" }
 compose-foundation = "org.jetbrains.compose.foundation:foundation:1.10.3"
 compose-runtime = "org.jetbrains.compose.runtime:runtime:1.10.3"
-compose-ui = "org.jetbrains.compose.ui:ui:1.10.3"
+compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-ui" }
+compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose-ui" }
 dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 dagger-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "dagger" }

--- a/gto-support-compose/build.gradle.kts
+++ b/gto-support-compose/build.gradle.kts
@@ -17,5 +17,26 @@ kotlin {
                 implementation(libs.compose.ui)
             }
         }
+
+        commonTest {
+            dependencies {
+                implementation(projects.gtoSupportAndroidxTestJunit)
+
+                implementation(libs.compose.ui.test)
+                implementation(libs.turbine)
+            }
+        }
+
+        androidMain {
+            dependencies {
+                implementation(libs.androidx.compose.ui.test.manifest)
+            }
+        }
+
+        androidUnitTest {
+            dependencies {
+                implementation(libs.robolectric)
+            }
+        }
     }
 }

--- a/gto-support-compose/src/androidUnitTest/resources/robolectric.properties
+++ b/gto-support-compose/src/androidUnitTest/resources/robolectric.properties
@@ -1,0 +1,1 @@
+sdk=NEWEST_SDK

--- a/gto-support-compose/src/commonMain/kotlin/org/ccci/gto/android/common/compose/util/StateFlow.kt
+++ b/gto-support-compose/src/commonMain/kotlin/org/ccci/gto/android/common/compose/util/StateFlow.kt
@@ -1,0 +1,14 @@
+package org.ccci.gto.android.common.compose.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@Composable
+fun <T> rememberStateFlow(value: T): StateFlow<T> {
+    val mutableStateFlow = remember { MutableStateFlow(value) }
+    mutableStateFlow.value = value
+    return remember(mutableStateFlow) { mutableStateFlow.asStateFlow() }
+}

--- a/gto-support-compose/src/commonTest/kotlin/org/ccci/gto/android/common/compose/util/StateFlowTest.kt
+++ b/gto-support-compose/src/commonTest/kotlin/org/ccci/gto/android/common/compose/util/StateFlowTest.kt
@@ -1,0 +1,56 @@
+package org.ccci.gto.android.common.compose.util
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import app.cash.turbine.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlinx.coroutines.flow.StateFlow
+import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
+import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+
+@OptIn(ExperimentalTestApi::class)
+@RunOnAndroidWith(AndroidJUnit4::class)
+class StateFlowTest {
+    @Test
+    fun `rememberStateFlow - initial value is correct`() = runComposeUiTest {
+        lateinit var flow: StateFlow<String>
+        setContent { flow = rememberStateFlow("hello") }
+
+        assertEquals("hello", flow.value)
+    }
+
+    @Test
+    fun `rememberStateFlow - emits updated values on recomposition`() = runComposeUiTest {
+        var input by mutableStateOf("initial")
+        lateinit var flow: StateFlow<String>
+        setContent { flow = rememberStateFlow(input) }
+
+        flow.test {
+            assertEquals("initial", awaitItem())
+
+            input = "updated"
+            waitForIdle()
+            assertEquals("updated", awaitItem())
+        }
+    }
+
+    @Test
+    fun `rememberStateFlow - StateFlow reference is stable across recompositions`() = runComposeUiTest {
+        var input by mutableStateOf("initial")
+        val instances = mutableListOf<StateFlow<String>>()
+        setContent { instances += rememberStateFlow(input) }
+
+        input = "updated"
+        waitForIdle()
+
+        assertEquals(2, instances.size, "Expected two StateFlow instances across two compositions")
+        instances.forEach {
+            assertSame(instances[0], it, "Expected StateFlow instance to be stable across recompositions")
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 pluginManagement {
     repositories {
         google()


### PR DESCRIPTION
## Summary
- Adds `rememberStateFlow(value: T): StateFlow<T>` composable utility to `gto-support-compose` that creates a stable `StateFlow` reference backed by a `MutableStateFlow` updated on each recomposition
- Adds Compose UI Test + Turbine tests covering initial value, value propagation on recomposition, and StateFlow reference stability
- Enables typesafe project accessors in `settings.gradle.kts` and converts `compose-ui` to a version-ref entry in the version catalog

## Test plan
- [ ] `./gradlew :gto-support-compose:test` passes
- [ ] `./gradlew :gto-support-compose:iosX64Test` passes
- [ ] `./gradlew :gto-support-compose:ktlintCheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)