### PR TITLE
remove Kotlin/Native background thread test configuration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,7 @@ This is a monorepo of 59+ Android/Kotlin Multiplatform (KMP) support libraries p
 ./gradlew test jvmTest
 
 # Run iOS tests (KMP modules with iOS targets)
-./gradlew iosX64Test iosX64BackgroundTest
+./gradlew iosX64Test
 
 # Run JavaScript tests
 ./gradlew jsBrowserTest jsNodeTest
@@ -62,7 +62,7 @@ This is a monorepo of 59+ Android/Kotlin Multiplatform (KMP) support libraries p
 
 Multiplatform modules support combinations of:
 - **Android** — primary target, publishes all library variants
-- **iOS** — arm64, x64, simulatorArm64; background thread test support enabled
+- **iOS** — arm64, x64, simulatorArm64
 - **JVM** — for non-Android JVM contexts
 - **JS** — browser + Node targets for select modules
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
           key: ${{ runner.os }}-konan-${{ github.sha }}
           restore-keys: ${{ runner.os }}-konan-
       - name: Run iOS Unit Tests
-        run: ./gradlew iosSimulatorArm64Test iosSimulatorArm64BackgroundTest iosX64Test iosX64BackgroundTest --scan
+        run: ./gradlew iosSimulatorArm64Test iosX64Test --scan
 
   js_tests:
     name: JS Unit Tests

--- a/build-logic/src/main/kotlin/MultiplatformConfiguration.kt
+++ b/build-logic/src/main/kotlin/MultiplatformConfiguration.kt
@@ -2,9 +2,6 @@ import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
-import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 
 // TODO: provide Project using the new multiple context receivers functionality.
 //       this is prototyped in 1.6.20 and will probably reach beta in Kotlin 1.8 or 1.9
@@ -20,9 +17,9 @@ internal fun KotlinMultiplatformExtension.configureAndroidTarget(project: Projec
 }
 
 fun KotlinMultiplatformExtension.configureIosTarget() {
-    iosArm64 { enableBackgroundTests() }
-    iosX64 { enableBackgroundTests() }
-    iosSimulatorArm64 { enableBackgroundTests() }
+    iosArm64()
+    iosX64()
+    iosSimulatorArm64()
 }
 
 fun KotlinMultiplatformExtension.configureJsTarget() {
@@ -37,20 +34,4 @@ fun KotlinMultiplatformExtension.configureJsTarget() {
 
 fun KotlinMultiplatformExtension.configureJvmTarget() {
     jvm()
-}
-
-private fun KotlinNativeTarget.enableBackgroundTests() {
-    // enable running ios tests on a background thread as well
-    // configuration copied from: https://github.com/square/okio/pull/929
-    if (this is KotlinNativeTargetWithTests<*>) {
-        binaries {
-            // Configure a separate test where code runs in background
-            test("background", setOf(DEBUG)) {
-                freeCompilerArgs += "-trw"
-            }
-        }
-        testRuns.create("background") {
-            setExecutionSourceFrom(binaries.getByName("backgroundDebugTest") as TestExecutable)
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- Removes the `enableBackgroundTests()` helper and background test binaries/runs from all iOS targets in `configureIosTarget()`
- Updates the CI workflow to drop the `iosSimulatorArm64BackgroundTest` and `iosX64BackgroundTest` tasks
- Updates CLAUDE.md to remove stale references to background tests

## Test plan
- [ ] iOS tests still run via `iosSimulatorArm64Test` and `iosX64Test` in CI
- [ ] ktlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)