### PR TITLE
MPDX-9656 feat(sync): add SyncTaskRegistry with Compose and Circuit support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ androidx-viewpager = { module = "androidx.viewpager:viewpager", version = "1.1.0
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version = "1.1.0" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version = "2.11.2" }
 circuit-overlay = { module = "com.slack.circuit:circuit-overlay", version.ref = "circuit" }
+circuit-runtime = { module = "com.slack.circuit:circuit-runtime", version.ref = "circuit" }
 compose-foundation = "org.jetbrains.compose.foundation:foundation:1.10.3"
 compose-runtime = "org.jetbrains.compose.runtime:runtime:1.10.3"
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-ui" }

--- a/gto-support-sync/build.gradle.kts
+++ b/gto-support-sync/build.gradle.kts
@@ -13,11 +13,13 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                compileOnly(libs.androidx.annotation)
                 implementation(libs.kermit)
                 implementation(libs.kotlin.coroutines)
 
                 // region Composables
                 compileOnly(libs.compose.runtime)
+                compileOnly(libs.circuit.runtime)
                 // endregion Composables
             }
         }
@@ -36,14 +38,26 @@ kotlin {
             dependencies {
                 // HACK: compileOnly dependencies aren't supported on Kotlin/Native, so promote them to implementation
                 implementation(libs.compose.runtime)
+                implementation(libs.circuit.runtime)
             }
         }
 
         commonTest {
             dependencies {
+                implementation(projects.gtoSupportAndroidxTestJunit)
+
+                implementation(libs.circuit.runtime)
                 implementation(libs.compose.runtime)
+                implementation(libs.compose.ui.test)
                 implementation(libs.kotlin.coroutines.test)
                 implementation(libs.turbine)
+            }
+        }
+
+        androidUnitTest {
+            dependencies {
+                implementation(libs.androidx.compose.ui.test.manifest)
+                implementation(libs.robolectric)
             }
         }
     }

--- a/gto-support-sync/src/androidUnitTest/resources/robolectric.properties
+++ b/gto-support-sync/src/androidUnitTest/resources/robolectric.properties
@@ -1,0 +1,1 @@
+sdk=NEWEST_SDK

--- a/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Circuit.kt
+++ b/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Circuit.kt
@@ -1,0 +1,26 @@
+package org.ccci.gto.android.common.sync
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import com.slack.circuit.runtime.CircuitContext
+
+@VisibleForTesting
+internal var CircuitContext.syncTaskRegistry: SyncTaskRegistry?
+    get() = tag() ?: parent?.syncTaskRegistry
+    set(value) = putTag(value)
+
+@Composable
+fun CircuitContext.rememberSyncTaskRegistry(syncTracker: SyncTracker = rememberSyncTracker()): SyncTaskRegistry {
+    val registry = remember(this, syncTracker) { SyncTaskRegistry(syncTracker) }
+    DisposableEffect(this, registry) {
+        syncTaskRegistry = registry
+        onDispose { syncTaskRegistry = null }
+    }
+    return registry
+}
+
+@Composable
+fun CircuitContext.rememberSyncTask(task: SyncTracker.(force: Boolean) -> Unit) =
+    syncTaskRegistry?.rememberSyncTask(task)

--- a/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Composable.kt
+++ b/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Composable.kt
@@ -1,0 +1,29 @@
+package org.ccci.gto.android.common.sync
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
+
+@Composable
+fun rememberSyncTaskRegistry(syncTracker: SyncTracker = rememberSyncTracker()) =
+    remember(syncTracker) { SyncTaskRegistry(syncTracker) }
+
+@Composable
+fun SyncTaskRegistry.rememberSyncTask(task: SyncTracker.(force: Boolean) -> Unit): String? {
+    var currId: String? by remember { mutableStateOf(null) }
+    DisposableEffect(this, task) {
+        val id = registerSyncTask(task)
+        currId = id
+        onDispose {
+            unregisterSyncTask(id)
+            Snapshot.withMutableSnapshot {
+                if (id == currId) currId = null
+            }
+        }
+    }
+    return currId
+}

--- a/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry.kt
+++ b/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry.kt
@@ -1,0 +1,28 @@
+package org.ccci.gto.android.common.sync
+
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.update
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalAtomicApi::class)
+class SyncTaskRegistry(val syncTracker: SyncTracker) {
+    private val tasks = AtomicReference(mapOf<String, SyncTracker.(force: Boolean) -> Unit>())
+
+    @OptIn(ExperimentalUuidApi::class)
+    fun registerSyncTask(task: SyncTracker.(force: Boolean) -> Unit): String {
+        val id = Uuid.generateV7().toString()
+        tasks.update { it + (id to task) }
+        syncTracker.task(false)
+        return id
+    }
+
+    fun unregisterSyncTask(id: String) {
+        tasks.update { it - id }
+    }
+
+    fun triggerSyncTasks(force: Boolean = false) {
+        tasks.load().values.forEach { syncTracker.it(force) }
+    }
+}

--- a/gto-support-sync/src/commonTest/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistryCircuitTest.kt
+++ b/gto-support-sync/src/commonTest/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistryCircuitTest.kt
@@ -1,0 +1,143 @@
+package org.ccci.gto.android.common.sync
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import com.slack.circuit.runtime.CircuitContext
+import com.slack.circuit.runtime.InternalCircuitApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlinx.coroutines.test.TestScope
+import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
+import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+
+@OptIn(ExperimentalTestApi::class, InternalCircuitApi::class)
+@RunOnAndroidWith(AndroidJUnit4::class)
+class SyncTaskRegistryCircuitTest {
+    private val testScope = TestScope()
+    private val syncTracker = SyncTracker(testScope.backgroundScope)
+
+    // region CircuitContext.rememberSyncTaskRegistry()
+    @Test
+    fun `rememberSyncTaskRegistry - wraps provided syncTracker`() = runComposeUiTest {
+        val context = CircuitContext(null)
+        lateinit var registry: SyncTaskRegistry
+
+        setContent { registry = context.rememberSyncTaskRegistry(syncTracker) }
+
+        assertSame(syncTracker, registry.syncTracker)
+    }
+
+    @Test
+    fun `rememberSyncTaskRegistry - sets registry on context`() = runComposeUiTest {
+        val context = CircuitContext(null)
+
+        setContent { context.rememberSyncTaskRegistry(syncTracker) }
+
+        assertNotNull(context.syncTaskRegistry)
+    }
+
+    @Test
+    fun `rememberSyncTaskRegistry - clears registry from context on dispose`() = runComposeUiTest {
+        val context = CircuitContext(null)
+        var active by mutableStateOf(true)
+
+        setContent {
+            if (active) context.rememberSyncTaskRegistry(syncTracker)
+        }
+
+        active = false
+        waitForIdle()
+
+        assertNull(context.syncTaskRegistry)
+    }
+
+    @Test
+    fun `rememberSyncTaskRegistry - stable across recompositions`() = runComposeUiTest {
+        val context = CircuitContext(null)
+        val instances = mutableListOf<SyncTaskRegistry>()
+        var trigger by mutableIntStateOf(0)
+
+        setContent {
+            trigger
+            instances += context.rememberSyncTaskRegistry(syncTracker)
+        }
+
+        trigger++
+        waitForIdle()
+
+        assertEquals(2, instances.size)
+        assertSame(instances[0], instances[1])
+    }
+    // endregion CircuitContext.rememberSyncTaskRegistry()
+
+    // region CircuitContext.rememberSyncTask()
+    @Test
+    fun `rememberSyncTask - registers task through context registry`() = runComposeUiTest {
+        val context = CircuitContext(null)
+        val registry = SyncTaskRegistry(syncTracker)
+        context.syncTaskRegistry = registry
+        val invocations = mutableListOf<Boolean>()
+
+        setContent { context.rememberSyncTask { force -> invocations.add(force) } }
+        invocations.clear()
+
+        registry.triggerSyncTasks()
+
+        assertEquals(listOf(false), invocations)
+    }
+
+    @Test
+    fun `rememberSyncTask - unregisters task on dispose`() = runComposeUiTest {
+        val context = CircuitContext(null)
+        val registry = SyncTaskRegistry(syncTracker)
+        context.syncTaskRegistry = registry
+        val invocations = mutableListOf<Boolean>()
+        var taskActive by mutableStateOf(true)
+
+        setContent {
+            if (taskActive) context.rememberSyncTask { force -> invocations.add(force) }
+        }
+        invocations.clear()
+
+        taskActive = false
+        waitForIdle()
+
+        registry.triggerSyncTasks()
+
+        assertEquals(emptyList(), invocations)
+    }
+
+    @Test
+    fun `rememberSyncTask - returns null when context has no registry`() = runComposeUiTest {
+        val context = CircuitContext(null)
+        var taskId: String? = "initial"
+
+        setContent { taskId = context.rememberSyncTask { } }
+
+        assertNull(taskId)
+    }
+
+    @Test
+    fun `rememberSyncTask - finds registry from parent context`() = runComposeUiTest {
+        val parentContext = CircuitContext(null)
+        val childContext = CircuitContext(parentContext)
+        val registry = SyncTaskRegistry(syncTracker)
+        parentContext.syncTaskRegistry = registry
+        val invocations = mutableListOf<Boolean>()
+
+        setContent { childContext.rememberSyncTask { force -> invocations.add(force) } }
+        invocations.clear()
+
+        registry.triggerSyncTasks()
+
+        assertEquals(listOf(false), invocations)
+    }
+    // endregion CircuitContext.rememberSyncTask()
+}

--- a/gto-support-sync/src/commonTest/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistryComposableTest.kt
+++ b/gto-support-sync/src/commonTest/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistryComposableTest.kt
@@ -1,0 +1,92 @@
+package org.ccci.gto.android.common.sync
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlinx.coroutines.test.TestScope
+import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
+import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+
+@OptIn(ExperimentalTestApi::class)
+@RunOnAndroidWith(AndroidJUnit4::class)
+class SyncTaskRegistryComposableTest {
+    private val testScope = TestScope()
+    private val syncTracker = SyncTracker(testScope.backgroundScope)
+
+    // region rememberSyncTaskRegistry()
+    @Test
+    fun `rememberSyncTaskRegistry - wraps provided syncTracker`() = runComposeUiTest {
+        lateinit var registry: SyncTaskRegistry
+        setContent { registry = rememberSyncTaskRegistry(syncTracker) }
+        assertSame(syncTracker, registry.syncTracker)
+    }
+
+    @Test
+    fun `rememberSyncTaskRegistry - stable across recompositions`() = runComposeUiTest {
+        val instances = mutableListOf<SyncTaskRegistry>()
+        var trigger by mutableIntStateOf(0)
+
+        setContent {
+            trigger
+            instances += rememberSyncTaskRegistry(syncTracker)
+        }
+
+        trigger++
+        waitForIdle()
+
+        assertEquals(2, instances.size)
+        assertSame(instances[0], instances[1])
+    }
+    // endregion rememberSyncTaskRegistry()
+
+    // region SyncTaskRegistry.rememberSyncTask()
+    @Test
+    fun `rememberSyncTask - task is registered on composition`() = runComposeUiTest {
+        val registry = SyncTaskRegistry(syncTracker)
+        val invocations = mutableListOf<Boolean>()
+
+        setContent { registry.rememberSyncTask { force -> invocations.add(force) } }
+        invocations.clear()
+
+        registry.triggerSyncTasks()
+
+        assertEquals(listOf(false), invocations)
+    }
+
+    @Test
+    fun `rememberSyncTask - task is unregistered on dispose`() = runComposeUiTest {
+        val registry = SyncTaskRegistry(syncTracker)
+        val invocations = mutableListOf<Boolean>()
+        var active by mutableStateOf(true)
+
+        setContent {
+            if (active) registry.rememberSyncTask { force -> invocations.add(force) }
+        }
+        invocations.clear()
+
+        active = false
+        waitForIdle()
+
+        registry.triggerSyncTasks()
+
+        assertEquals(emptyList(), invocations)
+    }
+
+    @Test
+    fun `rememberSyncTask - returns non-null ID after composition`() = runComposeUiTest {
+        val registry = SyncTaskRegistry(syncTracker)
+        var taskId: String? = null
+
+        setContent { taskId = registry.rememberSyncTask { } }
+
+        assertNotNull(taskId)
+    }
+    // endregion SyncTaskRegistry.rememberSyncTask()
+}

--- a/gto-support-sync/src/commonTest/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistryTest.kt
+++ b/gto-support-sync/src/commonTest/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistryTest.kt
@@ -1,0 +1,86 @@
+package org.ccci.gto.android.common.sync
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlinx.coroutines.test.TestScope
+
+class SyncTaskRegistryTest {
+    private val testScope = TestScope()
+    private val syncTracker = SyncTracker(testScope.backgroundScope)
+    private val registry = SyncTaskRegistry(syncTracker)
+
+    // region registerSyncTask()
+    @Test
+    fun `registerSyncTask - triggers task immediately with force=false`() {
+        val invocations = mutableListOf<Boolean>()
+        registry.registerSyncTask { force -> invocations.add(force) }
+        assertEquals(listOf(false), invocations)
+    }
+
+    @Test
+    fun `registerSyncTask - returns unique IDs`() {
+        val id1 = registry.registerSyncTask { }
+        val id2 = registry.registerSyncTask { }
+        assertNotEquals(id1, id2)
+    }
+    // endregion registerSyncTask()
+
+    // region unregisterSyncTask()
+    @Test
+    fun `unregisterSyncTask - task is not called after unregistration`() {
+        val invocations = mutableListOf<Boolean>()
+        val id = registry.registerSyncTask { force -> invocations.add(force) }
+        invocations.clear()
+
+        registry.unregisterSyncTask(id)
+        registry.triggerSyncTasks()
+
+        assertEquals(emptyList(), invocations)
+    }
+
+    @Test
+    fun `unregisterSyncTask - only removes the specified task`() {
+        val invocations1 = mutableListOf<Boolean>()
+        val invocations2 = mutableListOf<Boolean>()
+        val id1 = registry.registerSyncTask { force -> invocations1.add(force) }
+        registry.registerSyncTask { force -> invocations2.add(force) }
+        invocations1.clear()
+        invocations2.clear()
+
+        registry.unregisterSyncTask(id1)
+        registry.triggerSyncTasks()
+
+        assertEquals(emptyList(), invocations1)
+        assertEquals(listOf(false), invocations2)
+    }
+    // endregion unregisterSyncTask()
+
+    // region triggerSyncTasks()
+    @Test
+    fun `triggerSyncTasks - triggers all registered tasks`() {
+        val invocations1 = mutableListOf<Boolean>()
+        val invocations2 = mutableListOf<Boolean>()
+        registry.registerSyncTask { force -> invocations1.add(force) }
+        registry.registerSyncTask { force -> invocations2.add(force) }
+        invocations1.clear()
+        invocations2.clear()
+
+        registry.triggerSyncTasks()
+
+        assertEquals(listOf(false), invocations1)
+        assertEquals(listOf(false), invocations2)
+    }
+
+    @Test
+    fun `triggerSyncTasks - passes force value to all tasks`() {
+        val invocations = mutableListOf<Boolean>()
+        registry.registerSyncTask { force -> invocations.add(force) }
+        invocations.clear()
+
+        registry.triggerSyncTasks(force = true)
+
+        assertEquals(listOf(true), invocations)
+    }
+    // endregion triggerSyncTasks()
+}


### PR DESCRIPTION
## Summary

- Adds `SyncTaskRegistry` — an atomic registry that tracks named sync tasks and dispatches them via a `SyncTracker`
- Adds Compose integration: `rememberSyncTaskRegistry()` and `SyncTaskRegistry.rememberSyncTask()` composables that handle lifecycle-aware registration/unregistration
- Adds Circuit integration: `CircuitContext.rememberSyncTaskRegistry()` and `CircuitContext.rememberSyncTask()` with parent-context registry lookup; the `syncTaskRegistry` extension property is `internal @VisibleForTesting`

## Test plan

- [ ] `SyncTaskRegistryTest` — unit tests for `registerSyncTask`, `unregisterSyncTask`, `triggerSyncTasks`
- [ ] `SyncTaskRegistryComposableTest` — composition lifecycle, stability across recompositions, returned ID non-null after composition
- [ ] `SyncTaskRegistryCircuitTest` — context tag set/cleared on compose/dispose, parent context registry lookup, task registration/unregistration through context

🤖 Generated with [Claude Code](https://claude.com/claude-code)