### PR TITLE
feat(sync): support multiple keys in SyncTaskRegistry.rememberSyncTask

### DIFF
--- a/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Circuit.kt
+++ b/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Circuit.kt
@@ -24,3 +24,15 @@ fun CircuitContext.rememberSyncTaskRegistry(syncTracker: SyncTracker = rememberS
 @Composable
 fun CircuitContext.rememberSyncTask(task: SyncTracker.(force: Boolean) -> Unit) =
     syncTaskRegistry?.rememberSyncTask(task)
+
+@Composable
+fun CircuitContext.rememberSyncTask(key1: Any?, task: SyncTracker.(force: Boolean) -> Unit) =
+    syncTaskRegistry?.rememberSyncTask(key1, task)
+
+@Composable
+fun CircuitContext.rememberSyncTask(key1: Any?, key2: Any?, task: SyncTracker.(force: Boolean) -> Unit) =
+    syncTaskRegistry?.rememberSyncTask(key1, key2, task)
+
+@Composable
+fun CircuitContext.rememberSyncTask(vararg keys: Any?, task: SyncTracker.(force: Boolean) -> Unit) =
+    syncTaskRegistry?.rememberSyncTask(keys = keys, task)

--- a/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Composable.kt
+++ b/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Composable.kt
@@ -13,9 +13,21 @@ fun rememberSyncTaskRegistry(syncTracker: SyncTracker = rememberSyncTracker()) =
     remember(syncTracker) { SyncTaskRegistry(syncTracker) }
 
 @Composable
-fun SyncTaskRegistry.rememberSyncTask(task: SyncTracker.(force: Boolean) -> Unit): String? {
+fun SyncTaskRegistry.rememberSyncTask(task: SyncTracker.(force: Boolean) -> Unit) =
+    rememberSyncTask(keys = emptyArray(), task)
+
+@Composable
+fun SyncTaskRegistry.rememberSyncTask(key1: Any?, task: SyncTracker.(force: Boolean) -> Unit) =
+    rememberSyncTask(keys = arrayOf(key1), task)
+
+@Composable
+fun SyncTaskRegistry.rememberSyncTask(key1: Any?, key2: Any?, task: SyncTracker.(force: Boolean) -> Unit) =
+    rememberSyncTask(keys = arrayOf(key1, key2), task)
+
+@Composable
+fun SyncTaskRegistry.rememberSyncTask(vararg keys: Any?, task: SyncTracker.(force: Boolean) -> Unit): String? {
     var currId: String? by remember { mutableStateOf(null) }
-    DisposableEffect(this, task) {
+    DisposableEffect(this, *keys, task) {
         val id = registerSyncTask(task)
         currId = id
         onDispose {

--- a/gto-support-sync/src/commonTest/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistryComposableTest.kt
+++ b/gto-support-sync/src/commonTest/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistryComposableTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlinx.coroutines.test.TestScope
@@ -50,13 +51,15 @@ class SyncTaskRegistryComposableTest {
     @Test
     fun `rememberSyncTask - task is registered on composition`() = runComposeUiTest {
         val registry = SyncTaskRegistry(syncTracker)
+        var taskId: String? = null
         val invocations = mutableListOf<Boolean>()
 
-        setContent { registry.rememberSyncTask { force -> invocations.add(force) } }
+        setContent { taskId = registry.rememberSyncTask { force -> invocations.add(force) } }
         invocations.clear()
 
         registry.triggerSyncTasks()
 
+        assertNotNull(taskId)
         assertEquals(listOf(false), invocations)
     }
 
@@ -80,13 +83,63 @@ class SyncTaskRegistryComposableTest {
     }
 
     @Test
-    fun `rememberSyncTask - returns non-null ID after composition`() = runComposeUiTest {
+    fun `rememberSyncTask - stable across recompositions - no key`() = runComposeUiTest {
         val registry = SyncTaskRegistry(syncTracker)
+        var trigger by mutableIntStateOf(0)
         var taskId: String? = null
 
-        setContent { taskId = registry.rememberSyncTask { } }
+        setContent {
+            trigger
+            taskId = registry.rememberSyncTask { }
+        }
+        val initialId = taskId
+
+        trigger++
+        waitForIdle()
 
         assertNotNull(taskId)
+        assertEquals(initialId, taskId)
+    }
+
+    @Test
+    fun `rememberSyncTask - stable across recompositions - single key`() = runComposeUiTest {
+        val registry = SyncTaskRegistry(syncTracker)
+        var trigger by mutableIntStateOf(0)
+        var taskId: String? = null
+
+        setContent {
+            trigger
+            taskId = registry.rememberSyncTask("key") { }
+        }
+        val initialId = taskId
+
+        trigger++
+        waitForIdle()
+
+        assertNotNull(taskId)
+        assertEquals(initialId, taskId)
+    }
+
+    @Test
+    fun `rememberSyncTask - re-registers task when key changes`() = runComposeUiTest {
+        val registry = SyncTaskRegistry(syncTracker)
+        var taskId: String? = null
+        var key by mutableStateOf("initial")
+        val invocations = mutableListOf<Boolean>()
+
+        setContent { taskId = registry.rememberSyncTask(key) { force -> invocations.add(force) } }
+        val firstId = taskId
+        invocations.clear()
+
+        key = "changed"
+        waitForIdle()
+        invocations.clear()
+
+        registry.triggerSyncTasks()
+
+        assertNotNull(taskId)
+        assertNotEquals(firstId, taskId)
+        assertEquals(listOf(false), invocations)
     }
     // endregion SyncTaskRegistry.rememberSyncTask()
 }


### PR DESCRIPTION
## Summary

- Refactors `SyncTaskRegistry.rememberSyncTask` to a `vararg keys` base overload, mirroring the `DisposableEffect` pattern
- Adds `key1` and `key1, key2` convenience overloads so callers can trigger task re-registration on dependency changes
- Updates Circuit extension overloads to match the new signatures
- Adds tests verifying the task is re-registered and a new ID is returned when a key changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)