### PR TITLE
feat(pr-review): improve skill with inline comments, dismissal resolution, and lint

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -26,11 +26,12 @@ Use the branch name and commit log as the "title" in the review header.
 
 3. Identify all changed files and categorize them (new module, existing module change, build logic, source set restructure, dependency update, etc.).
 
-4. Run ktlint and record the result for the Code Style checklist:
+4. Run ktlint and lint, recording results for the Code Style checklist:
 ```
 ./gradlew :build-logic:ktlintCheck ktlintCheck
+./gradlew lint
 ```
-A failure is reported as a ❌ Must Fix item in the review output — it does not stop the rest of the review.
+Failures are reported as ❌ Must Fix items in the review output — they do not stop the rest of the review.
 
 5. Review each category using the checklist below.
 
@@ -133,7 +134,7 @@ Changes to convention plugins or configuration files affect every module — rev
 ### Code Style
 
 - [ ] Kotlin files pass ktlint (run `:ktlintCheck`)
-- [ ] Java files pass Checkstyle
+- [ ] Android lint passes (run `:lint`)
 - [ ] Files end with a trailing newline
 - [ ] No unused imports
 - [ ] `internal` used appropriately — avoid over-exposing API surface

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -38,7 +38,34 @@ A failure is reported as a ❌ Must Fix item in the review output — it does no
 
 7. Output a structured review (format below).
 
-8. After the review output, print:
+8. Post inline comments to the PR for every ⚠️ and ❌ finding that references a specific file and line number. Before posting, deduplicate against all existing comments (resolved or not) to avoid re-posting anything already raised:
+
+```bash
+# Get the head SHA, repo, and all existing review comments (resolved and unresolved)
+HEAD_SHA=$(gh pr view $ARGUMENTS --json headRefOid -q .headRefOid)
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+EXISTING=$(gh api repos/$REPO/pulls/$ARGUMENTS/comments --jq '[.[] | select(.in_reply_to_id == null) | {path:.path, line:.line, body:.body}]')
+```
+
+For each finding, check whether any existing comment (resolved or not) already covers the same file + line (or contains substantially the same text). Skip any finding that is already covered. Then bundle the remaining new comments into a single review submission:
+
+```bash
+gh api repos/$REPO/pulls/$ARGUMENTS/reviews \
+  --method POST \
+  --field commit_id="$HEAD_SHA" \
+  --field event="COMMENT" \
+  --field "comments[][path]=<file path>" \
+  --field "comments[][line]=<line number>" \
+  --field "comments[][side]=RIGHT" \
+  --field "comments[][body]=<finding text>
+
+🤖 Posted by [Claude Code](https://claude.ai/code)" \
+  # repeat --field "comments[]..." for each new finding
+```
+
+Use the exact file path from the diff and the line number in the current version of the file (RIGHT side). Each comment body should contain the full finding description. Always append the attribution footer `\n\n🤖 Posted by [Claude Code](https://claude.ai/code)` to each comment. If no new actionable findings exist (only ✅ items or all already commented), skip this step.
+
+9. After the review output, print:
 
 ```
 ---
@@ -168,4 +195,50 @@ When the user says `dismiss: <title> — <reason>` (in any form — "dismiss the
 **Dismissed by**: <git user.name>
 ```
 
-4. Confirm to the user what was added and that it will be suppressed in future reviews.
+4. If the current session reviewed a PR, find any open (unresolved) comment thread on that PR matching the dismissed issue. Use the GraphQL API to locate threads and resolve the matching one, replying with the dismissal reason first:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER=${REPO%%/*}
+REPONAME=${REPO##*/}
+
+# Find unresolved review threads
+gh api graphql -f query="
+{
+  repository(owner: \"$OWNER\", name: \"$REPONAME\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { id body path line }
+          }
+        }
+      }
+    }
+  }
+}"
+```
+
+Match the thread by file path, line number, or substantial text overlap with the dismissed finding. Then reply to the thread and resolve it:
+
+```bash
+# Reply to the thread's first comment explaining the dismissal
+gh api repos/$REPO/pulls/$PR_NUMBER/comments \
+  --method POST \
+  --field in_reply_to=<comment_id> \
+  --field body="Dismissed: <reason given by user>
+
+🤖 [Claude Code](https://claude.ai/code)"
+
+# Resolve the thread via GraphQL
+gh api graphql -f query="
+mutation {
+  resolveReviewThread(input: { threadId: \"<thread_node_id>\" }) {
+    thread { id isResolved }
+  }
+}"
+```
+
+5. Confirm to the user what was added and that it will be suppressed in future reviews.


### PR DESCRIPTION
## Summary
- Posts inline PR comments for every ⚠️ and ❌ finding that references a specific file/line, deduplicating against existing comments
- On dismiss, resolves the matching open review thread via GraphQL and replies with the dismissal reason
- Runs Android lint alongside ktlint as part of the review; swaps Checkstyle checklist item for lint

## Test plan
- [ ] Run `/pr-review <number>` on a PR with findings — verify inline comments are posted
- [ ] Dismiss a finding — verify the thread is resolved on GitHub with a reply
- [ ] Confirm lint runs and failures surface as ❌ Must Fix items

🤖 Generated with [Claude Code](https://claude.com/claude-code)