### PR TITLE
feat(sync): add LocalSyncTaskRegistry CompositionLocal

### DIFF
--- a/gto-support-sync/.editorconfig
+++ b/gto-support-sync/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+compose_allowed_composition_locals=LocalSyncTaskRegistry

--- a/gto-support-sync/build.gradle.kts
+++ b/gto-support-sync/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                compileOnly(libs.androidx.annotation)
+                implementation(libs.androidx.annotation)
                 implementation(libs.kermit)
                 implementation(libs.kotlin.coroutines)
 

--- a/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Circuit.kt
+++ b/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Circuit.kt
@@ -1,16 +1,15 @@
 package org.ccci.gto.android.common.sync
 
-import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import com.slack.circuit.runtime.CircuitContext
 
-@VisibleForTesting
-internal var CircuitContext.syncTaskRegistry: SyncTaskRegistry?
+var CircuitContext.syncTaskRegistry: SyncTaskRegistry?
     get() = tag() ?: parent?.syncTaskRegistry
     set(value) = putTag(value)
 
+@Deprecated("CircuitContext is meant to be used in a Presenter/Ui Factory and not in a Composable")
 @Composable
 fun CircuitContext.rememberSyncTaskRegistry(syncTracker: SyncTracker = rememberSyncTracker()): SyncTaskRegistry {
     val registry = remember(this, syncTracker) { SyncTaskRegistry(syncTracker) }
@@ -21,18 +20,22 @@ fun CircuitContext.rememberSyncTaskRegistry(syncTracker: SyncTracker = rememberS
     return registry
 }
 
+@Deprecated("CircuitContext is meant to be used in a Presenter/Ui Factory and not in a Composable")
 @Composable
 fun CircuitContext.rememberSyncTask(task: SyncTracker.(force: Boolean) -> Unit) =
     syncTaskRegistry?.rememberSyncTask(task)
 
+@Deprecated("CircuitContext is meant to be used in a Presenter/Ui Factory and not in a Composable")
 @Composable
 fun CircuitContext.rememberSyncTask(key1: Any?, task: SyncTracker.(force: Boolean) -> Unit) =
     syncTaskRegistry?.rememberSyncTask(key1, task)
 
+@Deprecated("CircuitContext is meant to be used in a Presenter/Ui Factory and not in a Composable")
 @Composable
 fun CircuitContext.rememberSyncTask(key1: Any?, key2: Any?, task: SyncTracker.(force: Boolean) -> Unit) =
     syncTaskRegistry?.rememberSyncTask(key1, key2, task)
 
+@Deprecated("CircuitContext is meant to be used in a Presenter/Ui Factory and not in a Composable")
 @Composable
 fun CircuitContext.rememberSyncTask(vararg keys: Any?, task: SyncTracker.(force: Boolean) -> Unit) =
     syncTaskRegistry?.rememberSyncTask(keys = keys, task)

--- a/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Composable.kt
+++ b/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Composable.kt
@@ -2,11 +2,14 @@ package org.ccci.gto.android.common.sync
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
+
+val LocalSyncTaskRegistry = compositionLocalOf<SyncTaskRegistry?> { null }
 
 @Composable
 fun rememberSyncTaskRegistry(syncTracker: SyncTracker = rememberSyncTracker()) =

--- a/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Composable.kt
+++ b/gto-support-sync/src/commonMain/kotlin/org/ccci/gto/android/common/sync/SyncTaskRegistry+Composable.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 
@@ -30,8 +31,9 @@ fun SyncTaskRegistry.rememberSyncTask(key1: Any?, key2: Any?, task: SyncTracker.
 @Composable
 fun SyncTaskRegistry.rememberSyncTask(vararg keys: Any?, task: SyncTracker.(force: Boolean) -> Unit): String? {
     var currId: String? by remember { mutableStateOf(null) }
-    DisposableEffect(this, *keys, task) {
-        val id = registerSyncTask(task)
+    val task by rememberUpdatedState(task)
+    DisposableEffect(this, *keys) {
+        val id = registerSyncTask { task(it) }
         currId = id
         onDispose {
             unregisterSyncTask(id)


### PR DESCRIPTION
## Summary
- Changes `androidx.annotation` from `compileOnly` to `implementation` in `gto-support-sync`
- Adds `LocalSyncTaskRegistry` CompositionLocal for injecting a `SyncTaskRegistry` through the composition tree

## Test plan
- [ ] Verify snapshot publishes successfully