### PR TITLE
GT-3046 fix(jsonapi): update proguard rules for JsonApiType classes

### DIFF
--- a/gto-support-jsonapi-core/src/main/resources/META-INF/proguard/jsonapi.pro
+++ b/gto-support-jsonapi-core/src/main/resources/META-INF/proguard/jsonapi.pro
@@ -9,7 +9,6 @@
 
 # Keep any JsonApiType object
 -keep @org.ccci.gto.android.common.jsonapi.annotation.JsonApiType class **
--keep @org.ccci.gto.android.common.jsonapi.annotation.JsonApiType class ** {
-  !transient <fields>;
-  @org.ccci.gto.android.common.jsonapi.annotation.JsonApiPostCreate <methods>;
+-keepclassmembers,allowoptimization,allowaccessmodification,allowrepackage @org.ccci.gto.android.common.jsonapi.annotation.JsonApiType class ** {
+    *;
 }


### PR DESCRIPTION
## Summary
- Update proguard rules for `@JsonApiType` annotated classes to use `-keepclassmembers` with `allowoptimization`, `allowaccessmodification`, and `allowrepackage`
- Allows class names to be obfuscated/optimized while preserving the members needed for JSON:API reflection

Ticket: GT-3046

## Test plan
- [ ] Verify minified app using JSON:API serialization continues to work correctly
- [ ] Confirm obfuscated `@JsonApiType` classes still serialize/deserialize properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)