### PR TITLE
Remove iosX64 KMP target

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,7 @@ This is a monorepo of 59+ Android/Kotlin Multiplatform (KMP) support libraries p
 ./gradlew test jvmTest
 
 # Run iOS tests (KMP modules with iOS targets)
-./gradlew iosX64Test
+./gradlew iosSimulatorArm64Test
 
 # Run JavaScript tests
 ./gradlew jsBrowserTest jsNodeTest
@@ -62,7 +62,7 @@ This is a monorepo of 59+ Android/Kotlin Multiplatform (KMP) support libraries p
 
 Multiplatform modules support combinations of:
 - **Android** — primary target, publishes all library variants
-- **iOS** — arm64, x64, simulatorArm64
+- **iOS** — arm64, simulatorArm64
 - **JVM** — for non-Android JVM contexts
 - **JS** — browser + Node targets for select modules
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
           key: ${{ runner.os }}-konan-${{ github.sha }}
           restore-keys: ${{ runner.os }}-konan-
       - name: Run iOS Unit Tests
-        run: ./gradlew iosSimulatorArm64Test iosX64Test --scan
+        run: ./gradlew iosSimulatorArm64Test --scan
 
   js_tests:
     name: JS Unit Tests

--- a/build-logic/src/main/kotlin/MultiplatformConfiguration.kt
+++ b/build-logic/src/main/kotlin/MultiplatformConfiguration.kt
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 fun KotlinMultiplatformExtension.configureIosTarget() {
     iosArm64()
-    iosX64()
     iosSimulatorArm64()
 }
 


### PR DESCRIPTION
## Summary
- Drop `iosX64()` from the multiplatform convention plugin; the iosSimulatorArm64 target covers modern Mac development
- Remove `iosX64Test` from the CI iOS tests step
- Update `.claude/CLAUDE.md` build commands and target list

## Test plan
- [ ] CI iOS tests step runs `iosSimulatorArm64Test` only and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)