### PR TITLE
chore: upgrade compileSdk to Android 37

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,7 +78,7 @@ Convention plugins centralize all Gradle configuration. Apply these instead of c
 | `gto-support.multiplatform-conventions` | KMP modules (no Android target) |
 | `gto-support.multiplatform-android-conventions` | KMP modules with Android target |
 
-These plugins configure: compile SDK 36 / min SDK 23 / target SDK 36, Java toolchain 17, 2GB test heap, Robolectric, ktlint, Kover, and publishing.
+These plugins configure: compile SDK 37 / min SDK 23, Java toolchain 17, 2GB test heap, Robolectric, ktlint, Kover, and publishing.
 
 ### Publishing
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -126,7 +126,7 @@ When an existing Android module is converted to KMP:
 ### Build Logic (`build-logic/`)
 
 Changes to convention plugins or configuration files affect every module — review carefully:
-- [ ] No SDK version changes without intentional justification (compileSdk 36, minSdk 23, targetSdk 36)
+- [ ] No SDK version changes without intentional justification (compileSdk 37, minSdk 23)
 - [ ] JVM toolchain version not changed inadvertently (Java 17)
 - [ ] Publishing configuration changes don't break group IDs (`org.ccci.gto.android` / `org.ccci.gto.android.testing`)
 - [ ] Test heap or sharding configuration changes are intentional

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 accompanist = "0.36.0"
 android-gradle-plugin = "9.2.1"
-android-sdk-compile = "36"
+android-sdk-compile = "37"
 android-sdk-min = "23"
 androidx-activity = "1.13.0"
 androidx-arch-core = "2.2.0"


### PR DESCRIPTION
## Summary
- Bump `android-sdk-compile` from 36 to 37 in `gradle/libs.versions.toml`
- Update CLAUDE.md and pr-review skill to reflect the new compileSdk and drop the obsolete targetSdk reference (libraries don't set targetSdk)

## Test plan
- [x] `./gradlew assemble` succeeds across all modules
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)